### PR TITLE
added basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Create a configuration file with aptly server and port, /etc/aptly-cli.conf (YAM
     :port: 8082
     :debug: false
 
+If you use Basic Authentication to protect your API, add username and password:
+
+    :username: api-user
+    :password: api-password
+
+Also make sure that your config file isn't world readable (```chmod o-rw /etc/aptly-cli.conf```)
+
 If a configuration file is not found the defaults in the example configuration file above will be used
 
 ## Usage - available aptly-cli commands

--- a/lib/aptly_file.rb
+++ b/lib/aptly_file.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end

--- a/lib/aptly_misc.rb
+++ b/lib/aptly_misc.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end

--- a/lib/aptly_package.rb
+++ b/lib/aptly_package.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end

--- a/lib/aptly_publish.rb
+++ b/lib/aptly_publish.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end

--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end

--- a/lib/aptly_snapshot.rb
+++ b/lib/aptly_snapshot.rb
@@ -12,6 +12,12 @@ module AptlyCli
     config = AptlyCli::AptlyLoad.new.configure_with("/etc/aptly-cli.conf")
     base_uri "http://#{config[:server]}:#{config[:port]}/api"
 
+    if config[:username]
+      if config[:password]
+        basic_auth "#{config[:username]}", "#{config[:password]}"
+      end
+    end
+
     if config[:debug] == true
       debug_output $stdout
     end


### PR DESCRIPTION
I'm proof-concepting to upload packages from a CI of your favourite choise to a aptly repo. As these are not compulsory on the same host (e.g. Travis CI/Gitlab CI/Drone/... to a private repo), the API is protected using basic authentication at the moment. Therefore i've added 2 new config values and the HTTParty option including README update.

By the way: Thanks for your gem ;)
