### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ruby:2.3
+MAINTAINER Zane Williamson <zane.williamson@gmail.com>
+
+# Install apt packages
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq && \
+    apt-get install -y -qq \
+        less \
+        locales && \
+    rm -rf /var/lib/apt/lists/*
+
+# Configure locale
+ARG LOCALE="C.UTF-8"
+RUN locale-gen "$LOCALE" && \
+    dpkg-reconfigure locales
+ENV LANG="$LOCALE" LC_ALL="$LOCALE"
+
+ADD . /app/
+ADD lib /app/lib
+
+VOLUME /app
+WORKDIR /app
+
+RUN gem install bundler && \
+    bundle install && \
+    rake install
+
+ENTRYPOINT ["aptly-cli"]


### PR DESCRIPTION
This enables building a Docker image with aptly-cli in it:

```
$ docker build -t aptly-cli .
...

$ alias aptly-cli='\
    docker run \
        -v ~/.config/aptly-cli/aptly-cli.conf:/etc/aptly-cli.conf \
        -it --rm --name=aptly-cli \
        aptly-cli'

$ aptly-cli repo_package_query --name develop --query 'Name (~ koala)'
Pall python-koala 0.0.41-1 7e42160a4f2f122f
Pall python-koala 0.0.50-1 4f03e421bcc6eaf5
Pall python-koala 0.0.42-1 aaa61514e74d89cf
```

You could even perhaps set up a [Docker Hub automated build](https://docs.docker.com/docker-hub/builds/) using this `Dockerfile` so that folks can them simply pull your `sepulworld/aptly-cli` image to get going.

```
$ alias aptly-cli='\
    docker run \
        -v ~/.config/aptly-cli/aptly-cli.conf:/etc/aptly-cli.conf \
        -it --rm --name=aptly-cli \
        seuplworld/aptly-cli'
```
