### PR TITLE
Add prompting mechanism for config values and add global options: --config, --server, --username, --password, --debug

### DIFF
--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -9,9 +9,37 @@ program :version, AptlyCli::VERSION
 program :description, 'Aptly repository API client'
 
 $config_file = '/etc/aptly-cli.conf'
+$server = nil
+$username = nil
+$password = nil
 
 global_option('-c', '--config FILE', 'Path to YAML config file') do |config_file|
   $config_file = config_file
+end
+
+global_option('-s', '--server SERVER', 'Host name or IP address') do |server|
+  $server = server
+end
+global_option('--username USERNAME', 'User name') do |username|
+  $username = username
+end
+global_option('--password PASSWORD', 'Password') do |password|
+  $password = password
+end
+
+def handle_global_options(options)
+  if $server
+    options.server = $server
+  end
+  if $username
+    options.username = $username
+  end
+  if $password
+    options.password = $password
+  end
+  if $debug
+    options.debug = $debug
+  end
 end
 
 command :file_list do |c|
@@ -22,7 +50,8 @@ command :file_list do |c|
   c.option '--directory DIRECTORY', String, 'Directory to list packages on server'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyFile.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyFile.new(config, options)
     if options.directory
       puts aptly_command.file_get(options.directory)
     else
@@ -40,7 +69,8 @@ command :file_upload do |c|
   c.option '--upload UPLOAD', String, 'Package(s) to upload'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyFile.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyFile.new(config, options)
     puts aptly_command.file_post(:file_uri => options.directory, :package => options.upload, :local_file => options.upload)
   end
 end
@@ -53,7 +83,8 @@ command :file_delete do |c|
   c.option '--target TARGET', String, 'Path to directory or specific package to delete'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyFile.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyFile.new(config, options)
     puts aptly_command.file_delete(options.target)
   end
 end
@@ -71,7 +102,8 @@ command :repo_create do |c|
   c.action do |args, options|
     puts options.name
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     repo_options = { :name => options.name.to_s, 
                      :comment => options.comment.to_s, 
                      :DefaultDistribution => options.default_distribution.to_s,
@@ -89,7 +121,8 @@ command :repo_delete do |c|
   c.option '--force'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     repo_options = { :name => options.name.to_s, 
                      :force => options.force.to_s }
     puts aptly_command.repo_delete(repo_options)
@@ -107,7 +140,8 @@ command :repo_edit do |c|
   c.option '--default_component COMPONENT', String, 'Edit DefaultComponent for repo'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     if options.default_distribution
       repo_options = { :DefaultDistribution => options.default_distribution.to_s }
     end
@@ -128,7 +162,8 @@ command :repo_list do |c|
   c.example 'description', 'aptly-cli repo_list'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     puts aptly_command.repo_list()
   end
 end
@@ -144,7 +179,8 @@ command :repo_package_query do |c|
   c.option '--format FORMAT', String, 'Format type to return, compact by default. "details" is an option'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     if options.query
       repo_options = { :name => options.name.to_s, :query => options.query.to_s }
     elsif options.with_deps and options.query.nil?
@@ -174,7 +210,8 @@ command :repo_upload do |c|
   c.option '--forcereplace', 'flag to replace file(s) already in the repo'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     puts aptly_command.repo_upload({ :name => options.name, :dir => options.dir,
                                      :file => options.file, :noremove => options.noremove,
                                      :forcereplace => options.forcereplace })
@@ -189,7 +226,8 @@ command :repo_show do |c|
   c.option '--name NAME', String, 'Local repository name, required'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyRepo.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
     puts aptly_command.repo_show(options.name)
   end
 end
@@ -204,7 +242,8 @@ command :publish_drop do |c|
   c.option '--force', 'force published repository removal even if component cleanup fails'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyPublish.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyPublish.new(config, options)
     puts aptly_command.publish_drop({ :prefix => options.prefix, :distribution => options.distribution, :force => options.force })
   end
 end
@@ -216,7 +255,8 @@ command :publish_list do |c|
   c.example 'List published repositories', 'aptly-cli publish_list'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyPublish.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyPublish.new(config, options)
     puts aptly_command.publish_list()
   end
 end
@@ -247,7 +287,8 @@ command :publish_repo do |c|
   c.option '--gpg_passphrase_file GPGPASSFILE', String, 'gpg passphrase file (local to aptly server/user)'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyPublish.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyPublish.new(config, options)
     puts aptly_command.publish_repo(options.name, { :sourcekind => options.sourcekind, :prefix => options.prefix,
                                                     :label => options.label, :distribution => options.distribution,
                                                     :origin => options.origin, :forceoverwrite => options.forceoverwrite,
@@ -275,7 +316,8 @@ command :publish_update do |c|
   c.option '--gpg_passphrase_file GPGPASSFILE', String, 'gpg passphrase file (local to aptly server/user)'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyPublish.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyPublish.new(config, options)
     puts aptly_command.publish_update({ :prefix => options.prefix, :distribution => options.distribution, :forceoverwrite => options.forceoverwrite,
                                                     :skip => options.gpg_skip, :batch => options.gpg_batch, :gpgKey => options.gpg_key,
                                                     :keyring => options.gpg_keyring, :secretKeyring => options.gpg_secret_keyring,
@@ -294,7 +336,8 @@ command :snapshot_create do |c|
   c.option '--description DESCRIPTION', String, 'Set description for snapshot'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_create(options.name, options.repo, options.description)
   end
 end
@@ -309,7 +352,8 @@ command :snapshot_delete do |c|
   c.option '--force', 'Force'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_delete(options.name, options.force)
   end
 end
@@ -323,7 +367,8 @@ command :snapshot_diff do |c|
   c.option '--withsnapshot WITHSNAPSHOT', String, 'Snapshot to diff against (right)'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_diff(options.name, options.withsnapshot)
   end
 end
@@ -337,7 +382,8 @@ command :snapshot_list do |c|
   c.option '--sort', String, 'Set sort by'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_list(options.sort)
   end
 end
@@ -355,7 +401,8 @@ command :snapshot_search do |c|
   c.option '--format FORMAT', String, 'Format the respone of the snapshot search results, compact by default.'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_search(options.name, { :query => options.query, :format => options.format, :withdeps => options.withdeps })
   end
 end
@@ -368,7 +415,8 @@ command :snapshot_show do |c|
   c.option '--name NAME', String, 'Local snapshot name, required'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_show(options.name)
   end
 end
@@ -383,7 +431,8 @@ command :snapshot_update do |c|
   c.option '--description DESCRIPTION', String, 'Update description for snapshot'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlySnapshot.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlySnapshot.new(config, options)
     puts aptly_command.snapshot_update(options.name, options.new_name, options.description)
   end
 end
@@ -396,7 +445,8 @@ command :graph do |c|
   c.option '--type GRAPH_TYPE', String, 'Type of graph to download, present options are png or svg'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyMisc.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyMisc.new(config, options)
     puts aptly_command.get_graph(options.type)
   end
 end
@@ -407,7 +457,8 @@ command :version do |c|
   c.example 'description', 'aptly-cli version'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)
-    aptly_command = AptlyCli::AptlyMisc.new(config)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyMisc.new(config, options)
     puts aptly_command.get_version()
   end
 end

--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -12,6 +12,7 @@ $config_file = '/etc/aptly-cli.conf'
 $server = nil
 $username = nil
 $password = nil
+$debug = false
 
 global_option('-c', '--config FILE', 'Path to YAML config file') do |config_file|
   $config_file = config_file
@@ -25,6 +26,9 @@ global_option('--username USERNAME', 'User name') do |username|
 end
 global_option('--password PASSWORD', 'Password') do |password|
   $password = password
+end
+global_option('--debug', 'Enable debug output') do
+  $debug = true
 end
 
 def handle_global_options(options)

--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -8,6 +8,12 @@ require 'aptly_cli'
 program :version, AptlyCli::VERSION 
 program :description, 'Aptly repository API client'
 
+$config_file = '/etc/aptly-cli.conf'
+
+global_option('-c', '--config FILE', 'Path to YAML config file') do |config_file|
+  $config_file = config_file
+end
+
 command :file_list do |c|
   c.syntax  = 'aptly-cli file_list [options]'
   c.summary = 'List all directories that contain uploaded files'
@@ -15,7 +21,8 @@ command :file_list do |c|
   c.example 'List all directories for file uploads', 'aptly-cli file_list'
   c.option '--directory DIRECTORY', String, 'Directory to list packages on server'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyFile.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyFile.new(config)
     if options.directory
       puts aptly_command.file_get(options.directory)
     else
@@ -32,7 +39,8 @@ command :file_upload do |c|
   c.option '--directory DIRECTORY', String, 'Directory to load packages into'
   c.option '--upload UPLOAD', String, 'Package(s) to upload'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyFile.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyFile.new(config)
     puts aptly_command.file_post(:file_uri => options.directory, :package => options.upload, :local_file => options.upload)
   end
 end
@@ -44,7 +52,8 @@ command :file_delete do |c|
   c.example 'Delete package redis-server found in redis upload directory', 'aptly-cli file_delete --target /redis/redis-server_2.8.3_i386-cc1.deb'
   c.option '--target TARGET', String, 'Path to directory or specific package to delete'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyFile.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyFile.new(config)
     puts aptly_command.file_delete(options.target)
   end
 end
@@ -61,7 +70,8 @@ command :repo_create do |c|
   c.option '--default_component COMPONENT', String, 'Default component when publishing from this local repo'
   c.action do |args, options|
     puts options.name
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     repo_options = { :name => options.name.to_s, 
                      :comment => options.comment.to_s, 
                      :DefaultDistribution => options.default_distribution.to_s,
@@ -78,7 +88,8 @@ command :repo_delete do |c|
   c.option '--name NAME', String, 'Local repository name, required'
   c.option '--force'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     repo_options = { :name => options.name.to_s, 
                      :force => options.force.to_s }
     puts aptly_command.repo_delete(repo_options)
@@ -95,7 +106,8 @@ command :repo_edit do |c|
   c.option '--default_distribution DISTRIBUTION', String, 'Edit DefaultDistribution for repo'
   c.option '--default_component COMPONENT', String, 'Edit DefaultComponent for repo'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     if options.default_distribution
       repo_options = { :DefaultDistribution => options.default_distribution.to_s }
     end
@@ -115,7 +127,8 @@ command :repo_list do |c|
   c.description = 'Show list of currently available local repositories'
   c.example 'description', 'aptly-cli repo_list'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     puts aptly_command.repo_list()
   end
 end
@@ -130,7 +143,8 @@ command :repo_package_query do |c|
   c.option '--with_deps', 'Return results with dependencies'
   c.option '--format FORMAT', String, 'Format type to return, compact by default. "details" is an option'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     if options.query
       repo_options = { :name => options.name.to_s, :query => options.query.to_s }
     elsif options.with_deps and options.query.nil?
@@ -159,7 +173,8 @@ command :repo_upload do |c|
   c.option '--noremove', 'Flag to not remove any files that were uploaded via File API after repo upload'
   c.option '--forcereplace', 'flag to replace file(s) already in the repo'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     puts aptly_command.repo_upload({ :name => options.name, :dir => options.dir,
                                      :file => options.file, :noremove => options.noremove,
                                      :forcereplace => options.forcereplace })
@@ -173,7 +188,8 @@ command :repo_show do |c|
   c.example 'description', 'aptly-cli repo_show --name megatronsoftware'
   c.option '--name NAME', String, 'Local repository name, required'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyRepo.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyRepo.new(config)
     puts aptly_command.repo_show(options.name)
   end
 end
@@ -187,7 +203,8 @@ command :publish_drop do |c|
   c.option '--distribution DISTRIBUTION', String, 'distribution'
   c.option '--force', 'force published repository removal even if component cleanup fails'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyPublish.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyPublish.new(config)
     puts aptly_command.publish_drop({ :prefix => options.prefix, :distribution => options.distribution, :force => options.force })
   end
 end
@@ -198,7 +215,8 @@ command :publish_list do |c|
   c.description = 'List published repositories.'
   c.example 'List published repositories', 'aptly-cli publish_list'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyPublish.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyPublish.new(config)
     puts aptly_command.publish_list()
   end
 end
@@ -228,7 +246,8 @@ command :publish_repo do |c|
   c.option '--gpg_passphrase GPGPASS', String, 'gpg key passphrase (if using over http, would be transmitted in clear text!)'
   c.option '--gpg_passphrase_file GPGPASSFILE', String, 'gpg passphrase file (local to aptly server/user)'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyPublish.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyPublish.new(config)
     puts aptly_command.publish_repo(options.name, { :sourcekind => options.sourcekind, :prefix => options.prefix,
                                                     :label => options.label, :distribution => options.distribution,
                                                     :origin => options.origin, :forceoverwrite => options.forceoverwrite,
@@ -255,7 +274,8 @@ command :publish_update do |c|
   c.option '--gpg_passphrase GPGPASS', String, 'gpg key passphrase (if using over http, would be transmitted in clear text!)'
   c.option '--gpg_passphrase_file GPGPASSFILE', String, 'gpg passphrase file (local to aptly server/user)'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyPublish.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyPublish.new(config)
     puts aptly_command.publish_update({ :prefix => options.prefix, :distribution => options.distribution, :forceoverwrite => options.forceoverwrite,
                                                     :skip => options.gpg_skip, :batch => options.gpg_batch, :gpgKey => options.gpg_key,
                                                     :keyring => options.gpg_keyring, :secretKeyring => options.gpg_secret_keyring,
@@ -273,7 +293,8 @@ command :snapshot_create do |c|
   c.option '--repo REPO', String, 'Name of repo to snapshot'
   c.option '--description DESCRIPTION', String, 'Set description for snapshot'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_create(options.name, options.repo, options.description)
   end
 end
@@ -287,7 +308,8 @@ command :snapshot_delete do |c|
   c.option '--name NAME', String, 'Local snapshot name, required'
   c.option '--force', 'Force'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_delete(options.name, options.force)
   end
 end
@@ -300,7 +322,8 @@ command :snapshot_diff do |c|
   c.option '--name NAME', String, 'Local snapshot name (left)'
   c.option '--withsnapshot WITHSNAPSHOT', String, 'Snapshot to diff against (right)'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_diff(options.name, options.withsnapshot)
   end
 end
@@ -313,7 +336,8 @@ command :snapshot_list do |c|
   c.example 'Return list sorted by time', 'aptly-cli snapshot_list --sort time'
   c.option '--sort', String, 'Set sort by'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_list(options.sort)
   end
 end
@@ -330,7 +354,8 @@ command :snapshot_search do |c|
   c.option '--withdeps', 'Include package dependencies'
   c.option '--format FORMAT', String, 'Format the respone of the snapshot search results, compact by default.'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_search(options.name, { :query => options.query, :format => options.format, :withdeps => options.withdeps })
   end
 end
@@ -342,7 +367,8 @@ command :snapshot_show do |c|
   c.example 'Show snapshot information for repo named megatronsoftware', 'aptly-cli snapshot_show --name megatronsoftware'
   c.option '--name NAME', String, 'Local snapshot name, required'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_show(options.name)
   end
 end
@@ -356,7 +382,8 @@ command :snapshot_update do |c|
   c.option '--new_name NEWNAME', String, 'New name for the snapshot'
   c.option '--description DESCRIPTION', String, 'Update description for snapshot'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlySnapshot.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlySnapshot.new(config)
     puts aptly_command.snapshot_update(options.name, options.new_name, options.description)
   end
 end
@@ -368,7 +395,8 @@ command :graph do |c|
   c.example 'description', 'aptly-cli graph png > ~/repo_graph.png'
   c.option '--type GRAPH_TYPE', String, 'Type of graph to download, present options are png or svg'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyMisc.new
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyMisc.new(config)
     puts aptly_command.get_graph(options.type)
   end
 end
@@ -378,8 +406,9 @@ command :version do |c|
   c.description = 'Display aptly server version'
   c.example 'description', 'aptly-cli version'
   c.action do |args, options|
-    aptly_command = AptlyCli::AptlyMisc.new
-    puts aptly_command.get_version() 
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    aptly_command = AptlyCli::AptlyMisc.new(config)
+    puts aptly_command.get_version()
   end
 end
 

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -1,0 +1,15 @@
+class AptlyCommand
+  def initialize
+    # Load aptly-cli.conf and establish base_uri
+    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
+    base_uri = "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
+    self.class.base_uri base_uri
+
+    if @config[:username]
+      if @config[:password]
+        self.class.basic_auth @config[:username].to_s, @config[:password].to_s
+      end
+    end
+    debug_output $stdout if @config[:debug] == true
+  end
+end

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -24,6 +24,21 @@ class AptlyCommand
         @config[k.to_sym] = ask("Enter a value for #{k}:")
       elsif v == '${PROMPT_PASSWORD}'
         @config[k.to_sym] = password("Enter a value for #{k}:")
+      elsif v == '${KEYRING}'
+        require 'keyring'
+
+        keyring = Keyring.new
+        value = keyring.get_password(@config[:server], @config[:username])
+
+        unless value
+          # Prompt for password...
+          value = password("Enter a value for #{k}:")
+
+          # ... and store in keyring
+          keyring.set_password(@config[:server], @config[:username], value)
+        end
+
+        @config[k.to_sym] = value
       end
     end
 

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -1,6 +1,27 @@
 class AptlyCommand
-  def initialize(config)
+  def initialize(config, options = nil)
     @config = config
+    options ||= Options.new
+
+    if options.server
+      @config[:server] = options.server
+    end
+
+    if options.username
+      @config[:username] = options.username
+    end
+
+    if options.password
+      @config[:password] = options.password
+    end
+
+    @config.each do |k, v|
+      if v == '${PROMPT}'
+        @config[k.to_sym] = ask("Enter a value for #{k}:")
+      elsif v == '${PROMPT_PASSWORD}'
+        @config[k.to_sym] = password("Enter a value for #{k}:")
+      end
+    end
 
     base_uri = "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
     self.class.base_uri base_uri

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -15,6 +15,10 @@ class AptlyCommand
       @config[:password] = options.password
     end
 
+    if options.debug
+      @config[:debug] = options.debug
+    end
+
     @config.each do |k, v|
       if v == '${PROMPT}'
         @config[k.to_sym] = ask("Enter a value for #{k}:")

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -1,7 +1,7 @@
 class AptlyCommand
-  def initialize
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
+  def initialize(config)
+    @config = config
+
     base_uri = "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
     self.class.base_uri base_uri
 

--- a/lib/aptly_file.rb
+++ b/lib/aptly_file.rb
@@ -1,27 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 
 module AptlyCli
   # Uploading file into Aptly
-  class AptlyFile
+  class AptlyFile < AptlyCommand
     include HTTMultiParty
     attr_accessor :file_uri, :package, :local_file_path
-
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-
-    debug_output $stdout if @config[:debug] == true
-
-    def initialize(file_uri=nil, package=nil, local_file_path=nil)
-    end
 
     def file_dir
       uri = '/files'

--- a/lib/aptly_load.rb
+++ b/lib/aptly_load.rb
@@ -26,14 +26,9 @@ module AptlyCli
     # Configure through hash
     def configure(opts = {})
       opts.each do |k, v|
-        if v == '${PROMPT}'
-          @config[k.to_sym] = ask("Enter a value for #{k}:")
-        elsif v == '${PROMPT_PASSWORD}'
-          @config[k.to_sym] = password("Enter a value for #{k}:")
-        elsif @valid_config_keys.include? k.to_sym
-          @config[k.to_sym] = v
-        end
+        config[k.to_sym] = v if @valid_config_keys.include? k.to_sym
       end
+
       @config
     end
 

--- a/lib/aptly_load.rb
+++ b/lib/aptly_load.rb
@@ -43,7 +43,8 @@ module AptlyCli
         config = YAML.load(IO.read(path_to_yaml_file))
       rescue Errno::ENOENT
         @log.warn(
-          'YAML configuration file couldn\'t be found at /etc/aptly-cli.conf. Using defaults.')
+          "YAML configuration file couldn\'t be found at " \
+           "#{path_to_yaml_file}. Using defaults.")
         return @config
       rescue Psych::SyntaxError
         @log.warn(

--- a/lib/aptly_load.rb
+++ b/lib/aptly_load.rb
@@ -20,14 +20,21 @@ module AptlyCli
         port: 8082
       }
 
-      @valid_config_keys = @config.keys
+      @valid_config_keys = @config.keys + [:username, :password, :debug]
     end
 
     # Configure through hash
     def configure(opts = {})
       opts.each do |k, v|
-        config[k.to_sym] = v if @valid_config_keys.include? k.to_sym
+        if v == '${PROMPT}'
+          @config[k.to_sym] = ask("Enter a value for #{k}:")
+        elsif v == '${PROMPT_PASSWORD}'
+          @config[k.to_sym] = password("Enter a value for #{k}:")
+        elsif @valid_config_keys.include? k.to_sym
+          @config[k.to_sym] = v
+        end
       end
+      @config
     end
 
     # Configure through yaml file

--- a/lib/aptly_misc.rb
+++ b/lib/aptly_misc.rb
@@ -1,24 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 require 'json'
 
 module AptlyCli
   # Misc Aptly Class
-  class AptlyMisc
+  class AptlyMisc < AptlyCommand
     include HTTMultiParty
-
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-
-    debug_output $stdout if @config[:debug] == true
 
     def get_graph(extension)
       uri = "/graph.#{extension}"

--- a/lib/aptly_package.rb
+++ b/lib/aptly_package.rb
@@ -1,24 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 require 'json'
 
 module AptlyCli
   # Aptly Package API
-  class AptlyPackage
+  class AptlyPackage < AptlyCommand
     include HTTMultiParty
-
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-
-    debug_output $stdout if @config[:debug] == true
 
     def package_show(package_key)
       uri = "/packages/#{package_key}"

--- a/lib/aptly_publish.rb
+++ b/lib/aptly_publish.rb
@@ -1,24 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 require 'json'
 
 module AptlyCli
   # :nodoc:
-  class AptlyPublish
+  class AptlyPublish < AptlyCommand
     include HTTMultiParty
-
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-
-    debug_output $stdout if @config[:debug] == true
 
     @@available_gpg_options = [:skip, :batch, :gpgKey, :keyring, :secretKeyring,
                               :passphrase, :passphraseFile]

--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -1,22 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 require 'json'
 
 module AptlyCli
   # Aptly class to work with Repo API
-  class AptlyRepo
+  class AptlyRepo < AptlyCommand
     include HTTMultiParty
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-    debug_output $stdout if @config[:debug] == true
 
     def repo_create(repo_options = { name: nil,
                                      comment: nil,

--- a/lib/aptly_snapshot.rb
+++ b/lib/aptly_snapshot.rb
@@ -1,24 +1,13 @@
 require 'aptly_cli/version'
+require 'aptly_command'
 require 'aptly_load'
 require 'httmultiparty'
 require 'json'
 
 module AptlyCli
   # Aptly class to work with Snapshot API
-  class AptlySnapshot
+  class AptlySnapshot < AptlyCommand
     include HTTMultiParty
-
-    # Load aptly-cli.conf and establish base_uri
-    @config = AptlyCli::AptlyLoad.new.configure_with('/etc/aptly-cli.conf')
-    base_uri "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-
-    if @config[:username]
-      if @config[:password]
-        basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-
-    debug_output $stdout if @config[:debug] == true
 
     def snapshot_delete(name, force=nil)
       uri = "/snapshots/#{name}"

--- a/test/fixtures/aptly-cli_prompts.yaml
+++ b/test/fixtures/aptly-cli_prompts.yaml
@@ -1,0 +1,5 @@
+---
+:server: 127.0.0.1
+:port: 8084
+:username: zane
+:password: ${PROMPT}

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,5 +6,5 @@ require 'aptly_cli'
 require 'minitest/autorun'
 
 class Options
-  attr_accessor :server, :username, :password
+  attr_accessor :server, :username, :password, :debug
 end

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -4,3 +4,7 @@ Coveralls.wear!
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'aptly_cli'
 require 'minitest/autorun'
+
+class Options
+  attr_accessor :server, :username, :password
+end

--- a/test/test_aptly_cli_configure.rb
+++ b/test/test_aptly_cli_configure.rb
@@ -30,13 +30,6 @@ class TestAptlyCli < Minitest::Test
       @test_aptly_load.configure_with('test/fixtures/aptly-cli.yaml')
   end
 
-  def test_that_config_loads_from_yaml_with_prompts
-    assert_equal(
-      { server: '127.0.0.1', port: 8084, proto: 'http',
-        username: 'zane', password: 'secret' },
-      @test_aptly_load.configure_with('test/fixtures/aptly-cli_prompts.yaml'))
-  end
-
   def test_that_config_loads_defaults_if_bad_yaml
     out, err = capture_subprocess_io do
       @test_aptly_load.configure_with('test/fixtures/aptly-cli_invalid.yaml')

--- a/test/test_aptly_cli_configure.rb
+++ b/test/test_aptly_cli_configure.rb
@@ -1,7 +1,15 @@
 require_relative 'minitest_helper'
 require 'aptly_cli'
 
-class TestAptlyCli < Minitest::Test 
+module AptlyCli
+  class AptlyLoad
+    def ask(_prompt)
+      'secret'
+    end
+  end
+end
+
+class TestAptlyCli < Minitest::Test
   attr_reader :test_aptly_load
 
   def setup
@@ -13,13 +21,20 @@ class TestAptlyCli < Minitest::Test
   end
 
   def test_that_config_loads
-    assert_equal ({ server: '127.0.0.2', port: 8083 }),
+    assert_equal ({ server: '127.0.0.2', port: 8083, proto: 'http' }),
       @test_aptly_load.configure({ server: '127.0.0.2', port: 8083 })
   end
-  
+
   def test_that_config_loads_from_yaml
-    assert_equal ({ server: '127.0.0.1', port: 8084 }),
+    assert_equal ({ server: '127.0.0.1', port: 8084, proto: 'http' }),
       @test_aptly_load.configure_with('test/fixtures/aptly-cli.yaml')
+  end
+
+  def test_that_config_loads_from_yaml_with_prompts
+    assert_equal(
+      { server: '127.0.0.1', port: 8084, proto: 'http',
+        username: 'zane', password: 'secret' },
+      @test_aptly_load.configure_with('test/fixtures/aptly-cli_prompts.yaml'))
   end
 
   def test_that_config_loads_defaults_if_bad_yaml
@@ -27,9 +42,9 @@ class TestAptlyCli < Minitest::Test
       @test_aptly_load.configure_with('test/fixtures/aptly-cli_invalid.yaml')
     end
     assert_includes out, ('WARN -- : YAML configuration file contains invalid '\
-    'syntax. Using defaults') 
+    'syntax. Using defaults')
   end
-  
+
   def test_that_config_loads_defaults_if_no_yaml
     out, err = capture_subprocess_io do
       @test_aptly_load.configure_with('test/fixtures/aptly-cli_no_yaml.yaml')

--- a/test/test_aptly_cli_configure.rb
+++ b/test/test_aptly_cli_configure.rb
@@ -50,6 +50,6 @@ class TestAptlyCli < Minitest::Test
       @test_aptly_load.configure_with('test/fixtures/aptly-cli_no_yaml.yaml')
     end
     assert_includes out, ('WARN -- : YAML configuration file couldn\'t '\
-    'be found at /etc/aptly-cli.conf. Using defaults.')
+    'be found at')
   end
 end

--- a/test/test_aptly_file.rb
+++ b/test/test_aptly_file.rb
@@ -5,13 +5,10 @@ require 'aptly_cli'
 
 def post_test_file(location)
   file_api_setup = AptlyCli::AptlyFile.new
-    AptlyCli::AptlyFile.new(
-      location.to_s,
-      'test_1.0_amd64.deb',
-      'test/fixtures/test_1.0_amd64.deb')
-    file_api_setup.file_post(file_uri: location.to_s,
-                       package: 'test/fixtures/test_1.0_amd64.deb',
-                       local_file: 'test/fixtures/test_1.0_amd64.deb') 
+  file_api_setup.file_post(
+    file_uri: location.to_s,
+    package: 'test/fixtures/test_1.0_amd64.deb',
+    local_file: 'test/fixtures/test_1.0_amd64.deb')
 end
 
 describe AptlyCli::AptlyFile do
@@ -49,9 +46,7 @@ end
 
 
 describe "API POST package files" do
-  let(:api_file) { AptlyCli::AptlyFile.new('/test',
-                                           'test_1.0_amd64.deb',
-                                           'test/fixtures/test_1.0_amd64.deb') }
+  let(:api_file) { AptlyCli::AptlyFile.new }
   let(:data_for_not_found) { api_file.file_get('test_package_not_here') }
 
   it 'must have a file_post method' do

--- a/test/test_aptly_file.rb
+++ b/test/test_aptly_file.rb
@@ -4,7 +4,8 @@ require 'minitest/autorun'
 require 'aptly_cli'
 
 def post_test_file(location)
-  file_api_setup = AptlyCli::AptlyFile.new
+  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  file_api_setup = AptlyCli::AptlyFile.new(config)
   file_api_setup.file_post(
     file_uri: location.to_s,
     package: 'test/fixtures/test_1.0_amd64.deb',
@@ -26,7 +27,8 @@ describe AptlyCli::AptlyFile do
 end
 
 describe 'API GET files' do
-  let(:file_api) { AptlyCli::AptlyFile.new }
+  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  let(:file_api) { AptlyCli::AptlyFile.new(config) }
   post_test_file('/testdirfile') 
   
   def test_file_get
@@ -35,7 +37,8 @@ describe 'API GET files' do
 end
 
 describe 'API DELETE files' do
-  let(:file_api) { AptlyCli::AptlyFile.new }
+  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  let(:file_api) { AptlyCli::AptlyFile.new(config) }
   post_test_file('/testdirfiledelete') 
   
   def test_file_delete
@@ -46,7 +49,8 @@ end
 
 
 describe "API POST package files" do
-  let(:api_file) { AptlyCli::AptlyFile.new }
+  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  let(:api_file) { AptlyCli::AptlyFile.new(config) }
   let(:data_for_not_found) { api_file.file_get('test_package_not_here') }
 
   it 'must have a file_post method' do

--- a/test/test_aptly_misc.rb
+++ b/test/test_aptly_misc.rb
@@ -23,7 +23,8 @@ describe AptlyCli::AptlyMisc do
   end
 
   describe 'API Get graph' do
-    let(:misc_api) { AptlyCli::AptlyMisc.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:misc_api) { AptlyCli::AptlyMisc.new(config) }
 
     def test_graph_request_for_SVG_returns_200 
       assert_equal '200', misc_api.get_graph(extension = 'svg').code.to_s
@@ -35,7 +36,8 @@ describe AptlyCli::AptlyMisc do
   end
 
   describe 'API Get Version' do
-    let(:misc_api) { AptlyCli::AptlyMisc.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:misc_api) { AptlyCli::AptlyMisc.new(config) }
 
     def test_version_returns_valid
       assert_equal '{"Version"=>"0.9.7"}', misc_api.get_version.to_s

--- a/test/test_aptly_publish.rb
+++ b/test/test_aptly_publish.rb
@@ -9,8 +9,9 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API List Publish' do
-    let(:publish_api) { AptlyCli::AptlyPublish.new }
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_publish_list
       publish_api.publish_drop(distribution: 'publishlisttest1', force: 1)
@@ -39,8 +40,9 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Drop Publish' do
-    let(:publish_api) { AptlyCli::AptlyPublish.new }
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_publish_drop
       publish_api.publish_drop(distribution: 'precisetestdrop', force: 1)
@@ -58,8 +60,9 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Publish Repo' do
-    let(:publish_api) { AptlyCli::AptlyPublish.new }
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_publish_snapshot
       snapshot_api.snapshot_delete('testrepo_snap_to_publish', 1)
@@ -77,8 +80,9 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Update Publish Point' do
-    let(:publish_api) { AptlyCli::AptlyPublish.new }
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_publish_single_repo
       publish_api.publish_drop(distribution: 'precisetest3', force: 1)

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -9,10 +9,7 @@ describe AptlyCli::AptlyRepo do
 
   describe 'API Upload to Repo' do
     let(:repo_api) { AptlyCli::AptlyRepo.new }
-    let(:file_api) { AptlyCli::AptlyFile.new(
-      '/testdir',
-      'test_1.0_amd64.deb',
-      'test/fixtures/test_1.0_amd64.deb')}
+    let(:file_api) { AptlyCli::AptlyFile.new }
 
     def test_repo_upload
       file_api.file_post(file_uri: '/testdir',
@@ -60,11 +57,8 @@ describe AptlyCli::AptlyRepo do
 
   describe 'API Package Query Repo' do
     let(:repo_api) { AptlyCli::AptlyRepo.new }
-    let(:file_api) { AptlyCli::AptlyFile.new(
-      '/testdir2',
-      'test_1.0_amd64.deb',
-      'test/fixtures/test_1.0_amd64.deb')}
-    
+    let(:file_api) { AptlyCli::AptlyFile.new }
+
     def test_package_query_with_name
       repo_api.repo_delete(name: 'testrepotoquery',
                            force: true)

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -8,8 +8,9 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Upload to Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
-    let(:file_api) { AptlyCli::AptlyFile.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
+    let(:file_api) { AptlyCli::AptlyFile.new(config) }
 
     def test_repo_upload
       file_api.file_post(file_uri: '/testdir',
@@ -25,7 +26,8 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Create Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_creation
       repo_api.repo_delete(name: 'testrepocreate',
@@ -40,7 +42,8 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Show Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_show
       repo_api.repo_delete(name: 'testrepotoshow',
@@ -56,8 +59,9 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Package Query Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
-    let(:file_api) { AptlyCli::AptlyFile.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
+    let(:file_api) { AptlyCli::AptlyFile.new(config) }
 
     def test_package_query_with_name
       repo_api.repo_delete(name: 'testrepotoquery',
@@ -80,7 +84,8 @@ describe AptlyCli::AptlyRepo do
   end
   
   describe 'API List Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_list_repo_http_response
       assert_equal repo_api.repo_list.code.to_s, '200'
@@ -88,7 +93,8 @@ describe AptlyCli::AptlyRepo do
   end
   
   describe 'API Edit Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_edit_default_distribution
       repo_api.repo_delete(name: 'testrepotoedit',
@@ -108,7 +114,8 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Delete Repo' do
-    let(:repo_api) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_delete
       repo_api.repo_create(name: 'testrepodelete',
@@ -121,7 +128,8 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Upload to Repo, failure scenario' do
-    let(:repo_api_fail) { AptlyCli::AptlyRepo.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:repo_api_fail) { AptlyCli::AptlyRepo.new(config) }
     let(:data) { repo_api_fail.repo_upload({ name: 'testrepo',
                                            dir: 'rockpackages',
                                            file: 'test_package_not_here',

--- a/test/test_aptly_snapshot.rb
+++ b/test/test_aptly_snapshot.rb
@@ -9,8 +9,9 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Delete Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
-    let(:publish_api) { AptlyCli::AptlyPublish.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
+    let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
 
     def test_snapshot_force_delete
       snapshot_api.snapshot_create(
@@ -50,7 +51,8 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Create and List Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_create
       snapshot_api.snapshot_delete(
@@ -76,7 +78,8 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Update Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_update_name
       snapshot_api.snapshot_delete('testrepo_snap_update_test', 1)
@@ -109,7 +112,8 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Search Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_search_for_all_with_details
       snapshot_api.snapshot_delete('testrepo_snap_for_search_test', 1)
@@ -135,10 +139,12 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Diff Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
   end
 
   describe 'API Show Snapshot' do
-    let(:snapshot_api) { AptlyCli::AptlySnapshot.new }
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
   end
 end


### PR DESCRIPTION
This allows not keeping passwords and such in the config file.

E.g.: In `/etc/aptly-cli.conf`:

``` yaml

---
:proto: http
:server: 10.3.0.46
:port: 8082
:debug: false
:username: ${PROMPT}
:password: ${PROMPT_PASSWORD}
```

The tool will prompt for the specified values, where `${PROMPT}` results in a regular prompt and `${PROMPT_PASSWORD}` results in a password prompt where the input is replaced by asterisks -- e.g.:

```
$ aptly-cli version
Enter a value for username:
zane
Enter a value for password:
***************
{"Version"=>"0.9.7"}
```

This also eliminates a bunch of duplicated code in all of the command classes by having them inherit from a common base class. This was actually essential because otherwise, every required file would trigger a config load and thus prompting for any needed values over and over again.

The `--config` (`-c`) option allows specifying an alternative config file -- e.g.:

```
$ aptly-cli -c ~/.config/aptly-cli/aptly-cli.conf repo_list
```

and the `--server`, `--username`, and `--password` options allow specifying those things on the command-line and not even requiring a config file:

```
$ aptly-cli --server 10.3.0.46 --username marca --password '${PROMPT_PASSWORD}' repo_list
```

Note that you can use `${PROMPT}` and `${PROMPT_PASSWORD}` in the values of these options, just as you can in a config file.
