### PR TITLE
Add --port option + help tweaks

### DIFF
--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -5,11 +5,12 @@ require 'rubygems'
 require 'commander/import'
 require 'aptly_cli'
 
-program :version, AptlyCli::VERSION 
-program :description, 'Aptly repository API client'
+program :version, AptlyCli::VERSION
+program :description, 'Aptly repository API client (https://github.com/sepulworld/aptly_cli)'
 
 $config_file = '/etc/aptly-cli.conf'
 $server = nil
+$port = nil
 $username = nil
 $password = nil
 $debug = false
@@ -18,13 +19,16 @@ global_option('-c', '--config FILE', 'Path to YAML config file') do |config_file
   $config_file = config_file
 end
 
-global_option('-s', '--server SERVER', 'Host name or IP address') do |server|
+global_option('-s', '--server SERVER', 'Host name or IP address of Aptly API server') do |server|
   $server = server
 end
-global_option('--username USERNAME', 'User name') do |username|
+global_option('-p', '--port PORT', 'Port of Aptly API server') do |port|
+  $port = port
+end
+global_option('--username USERNAME', 'User name or \'${PROMPT}\'') do |username|
   $username = username
 end
-global_option('--password PASSWORD', 'Password') do |password|
+global_option('--password PASSWORD', 'Password or \'${PROMPT_PASSWORD}\' or \'${KEYRING}\'') do |password|
   $password = password
 end
 global_option('--debug', 'Enable debug output') do
@@ -34,6 +38,9 @@ end
 def handle_global_options(options)
   if $server
     options.server = $server
+  end
+  if $port
+    options.port = $port
   end
   if $username
     options.username = $username

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -1,61 +1,71 @@
-class AptlyCommand
-  def initialize(config, options = nil)
-    @config = config
-    options ||= Options.new
+module AptlyCli
+  class AptlyCommand
+    include HTTMultiParty
 
-    if options.respond_to?(:server) && options.server
-      @config[:server] = options.server
-    end
+    attr_accessor :config
 
-    if options.respond_to?(:port) && options.port
-      @config[:port] = options.port
-    end
+    def initialize(config, options = nil)
+      @config = config
+      options ||= Options.new
 
-    if options.respond_to?(:username) && options.username
-      @config[:username] = options.username
-    end
+      if options.respond_to?(:server) && options.server
+        @config[:server] = options.server
+      end
 
-    if options.respond_to?(:password) && options.password
-      @config[:password] = options.password
-    end
+      if options.respond_to?(:port) && options.port
+        @config[:port] = options.port
+      end
 
-    if options.respond_to?(:debug) && options.debug
-      @config[:debug] = options.debug
-    end
+      if options.respond_to?(:username) && options.username
+        @config[:username] = options.username
+      end
 
-    @config.each do |k, v|
-      if v == '${PROMPT}'
-        @config[k.to_sym] = ask("Enter a value for #{k}:")
-      elsif v == '${PROMPT_PASSWORD}'
-        @config[k.to_sym] = password("Enter a value for #{k}:")
-      elsif v == '${KEYRING}'
-        require 'keyring'
+      if options.respond_to?(:password) && options.password
+        @config[:password] = options.password
+      end
 
-        keyring = Keyring.new
-        keychain_item_name = 'Aptly API server at ' + \
-                             @config[:server] + ':' + @config[:port].to_s
-        value = keyring.get_password(keychain_item_name, @config[:username])
+      if options.respond_to?(:debug) && options.debug
+        @config[:debug] = options.debug
+      end
 
-        unless value
-          # Prompt for password...
-          value = password("Enter a value for #{k}:")
+      @config.each do |k, v|
+        if v == '${PROMPT}'
+          @config[k.to_sym] = ask("Enter a value for #{k}:")
+        elsif v == '${PROMPT_PASSWORD}'
+          @config[k.to_sym] = password("Enter a value for #{k}:")
+        elsif v == '${KEYRING}'
+          require 'keyring'
 
-          # ... and store in keyring
-          keyring.set_password(keychain_item_name, @config[:username], value)
+          keyring = Keyring.new
+          keychain_item_name = 'Aptly API server at ' + \
+                               @config[:server] + ':' + @config[:port].to_s
+          value = keyring.get_password(keychain_item_name, @config[:username])
+
+          unless value
+            # Prompt for password...
+            value = password("Enter a value for #{k}:")
+
+            # ... and store in keyring
+            keyring.set_password(keychain_item_name, @config[:username], value)
+          end
+
+          @config[k.to_sym] = value
         end
+      end
 
-        @config[k.to_sym] = value
+      base_uri = "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}" \
+                 '/api'
+      self.class.base_uri base_uri
+
+      if @config[:username]
+        if @config[:password]
+          self.class.basic_auth @config[:username].to_s, @config[:password].to_s
+        end
+      end
+
+      if self.respond_to?(:debug_output)
+        debug_output $stdout if @config[:debug] == true
       end
     end
-
-    base_uri = "#{@config[:proto]}://#{@config[:server]}:#{@config[:port]}/api"
-    self.class.base_uri base_uri
-
-    if @config[:username]
-      if @config[:password]
-        self.class.basic_auth @config[:username].to_s, @config[:password].to_s
-      end
-    end
-    debug_output $stdout if @config[:debug] == true
   end
 end

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -3,19 +3,23 @@ class AptlyCommand
     @config = config
     options ||= Options.new
 
-    if options.server
+    if options.respond_to?(:server) && options.server
       @config[:server] = options.server
     end
 
-    if options.username
+    if options.respond_to?(:port) && options.port
+      @config[:port] = options.port
+    end
+
+    if options.respond_to?(:username) && options.username
       @config[:username] = options.username
     end
 
-    if options.password
+    if options.respond_to?(:password) && options.password
       @config[:password] = options.password
     end
 
-    if options.debug
+    if options.respond_to?(:debug) && options.debug
       @config[:debug] = options.debug
     end
 
@@ -28,14 +32,16 @@ class AptlyCommand
         require 'keyring'
 
         keyring = Keyring.new
-        value = keyring.get_password(@config[:server], @config[:username])
+        keychain_item_name = 'Aptly API server at ' + \
+                             @config[:server] + ':' + @config[:port].to_s
+        value = keyring.get_password(keychain_item_name, @config[:username])
 
         unless value
           # Prompt for password...
           value = password("Enter a value for #{k}:")
 
           # ... and store in keyring
-          keyring.set_password(@config[:server], @config[:username], value)
+          keyring.set_password(keychain_item_name, @config[:username], value)
         end
 
         @config[k.to_sym] = value

--- a/lib/aptly_file.rb
+++ b/lib/aptly_file.rb
@@ -6,7 +6,6 @@ require 'httmultiparty'
 module AptlyCli
   # Uploading file into Aptly
   class AptlyFile < AptlyCommand
-    include HTTMultiParty
     attr_accessor :file_uri, :package, :local_file_path
 
     def file_dir

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -6,5 +6,5 @@ require 'aptly_cli'
 require 'minitest/autorun'
 
 class Options
-  attr_accessor :server, :username, :password, :debug
+  attr_accessor :server, :port, :username, :password, :debug
 end

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -1,0 +1,67 @@
+require 'minitest_helper.rb'
+require 'minitest/autorun'
+
+require 'aptly_cli'
+
+module AptlyCli
+  class AptlyCommand
+    def ask(_prompt)
+      'zane'
+    end
+
+    def password(_prompt)
+      'secret'
+    end
+  end
+end
+
+describe AptlyCli::AptlyCommand do
+  it 'has a default config' do
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    cmd = AptlyCli::AptlyCommand.new(config)
+    cmd.config[:proto].must_equal 'http'
+    cmd.config[:server].must_equal '127.0.0.1'
+    cmd.config[:port].must_equal 8082
+  end
+
+  it 'accepts empty options and no config changes' do
+    options = Options.new
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    cmd = AptlyCli::AptlyCommand.new(config, options)
+    cmd.config[:proto].must_equal 'http'
+    cmd.config[:server].must_equal '127.0.0.1'
+    cmd.config[:port].must_equal 8082
+  end
+
+  it 'can take options and updates its config accordingly' do
+    options = Options.new
+    options.server = 'my-server'
+    options.port = 9000
+    options.username = 'me'
+    options.password = 'secret'
+    options.debug = true
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    cmd = AptlyCli::AptlyCommand.new(config, options)
+    cmd.config[:server].must_equal 'my-server'
+    cmd.config[:port].must_equal 9000
+    cmd.config[:username].must_equal 'me'
+    cmd.config[:password].must_equal 'secret'
+    cmd.config[:debug].must_equal true
+  end
+
+  it 'can process an option with \'${PROMPT}\' in it' do
+    options = Options.new
+    options.username = '${PROMPT}'
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    cmd = AptlyCli::AptlyCommand.new(config, options)
+    cmd.config[:username].must_equal 'zane'
+  end
+
+  it 'can process an option with \'${PROMPT_PASSWORD}\' in it' do
+    options = Options.new
+    options.username = '${PROMPT_PASSWORD}'
+    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    cmd = AptlyCli::AptlyCommand.new(config, options)
+    cmd.config[:username].must_equal 'secret'
+  end
+end


### PR DESCRIPTION
This adds a `--port` global option, which I neglected to add before.

It also tweaks some of the descriptions in the help.
