### PR TITLE
Devtools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in aptly_cli.gemspec
 gemspec
 
+gem "keyring", require: false, platform: :ruby_20
+
 group :test do
   gem "simplecov", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gemspec
 gem "keyring", require: false, platform: :ruby_20
 
 group :test do
+  gem "rubocop", require: false
   gem "simplecov", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in aptly_cli.gemspec
 gemspec
+
+group :test do
+  gem "simplecov", require: false
+end

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,13 @@ require "bundler/gem_tasks"
 
 require "rake/testtask"
 
+begin
+  require 'rubocop/rake_task'
+	RuboCop::RakeTask.new
+rescue LoadError
+  puts 'Install "rubocop" to enable rubocop Rake task.'
+end
+
 Rake::TestTask.new do |t|
   t.libs << "lib"
   t.libs << "test"

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,5 +1,14 @@
 require 'coveralls'
-Coveralls.wear!
+require 'simplecov'
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
+
+SimpleCov.start do
+  add_filter '/\.bundle/'
+end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'aptly_cli'


### PR DESCRIPTION
### Enables measuring coverage locally

```
$ bundle exec rake test
...
Coverage report generated for Unit Tests to /Users/marca/dev/git-repos/aptly_cli/coverage. 521 / 566 LOC (92.05%) covered.
[Coveralls] Outside the CI environment, not sending data.

$ open coverage/index.html
```

<img width="1426" alt="screen shot 2016-07-21 at 4 05 56 pm" src="https://cloud.githubusercontent.com/assets/305268/17042294/2f28f8f8-4f61-11e6-8a92-f0d921e36187.png">
### Enable rubocop and Rake task for it

```
$ rake -T
Install "rubocop" to enable rubocop Rake task.
rake build              # Build aptly_cli-0.3.0.gem into the pkg directory
rake clean              # Remove any temporary products
rake clobber            # Remove any generated files
rake docker_build       # Docker build image
rake docker_list_aptly  # List Docker Aptly running containers
rake docker_pull        # Pull Docker image to Docker Hub
rake docker_push        # Push Docker image to Docker Hub
rake docker_restart     # Restart Aptly docker container
rake docker_run         # Start Aptly Docker container on port 8082
rake docker_show_logs   # Show running Aptly process Docker stdout logs
rake docker_stop        # Stop running Aptly Docker containers
rake install            # Build and install aptly_cli-0.3.0.gem into system gems
rake install:local      # Build and install aptly_cli-0.3.0.gem into system gems without network access
rake release[remote]    # Create tag v0.3.0 and build and push aptly_cli-0.3.0.gem to Rubygems
rake test               # Run tests

$ bundle exec rake -T | grep rubocop
rake rubocop               # Run RuboCop
rake rubocop:auto_correct  # Auto-correct RuboCop offenses

$ bundle exec rake rubocop
Running RuboCop...
Inspecting 24 files
WCCCWC..CCCC.CCC.WCWCCCC
...
```
