### PR TITLE
moving developer gems to gemspec file, so they will show up on RubyGe…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,3 @@ source 'https://rubygems.org'
 gemspec
 
 gem "keyring", require: false, platform: :ruby_20
-
-group :test do
-  gem "rubocop", require: false
-  gem "simplecov", require: false
-end

--- a/aptly_cli.gemspec
+++ b/aptly_cli.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
 
   if spec.respond_to?(:metadata)
     spec.metadata['allowed_push_host'] = "https://rubygems.org"
+    spec.metadata['optional_gems']     = "keyring"
   end
 
   spec.summary               = %q{Command line client to interact with Aptly package management system}

--- a/aptly_cli.gemspec
+++ b/aptly_cli.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "rubocop"
 
   spec.add_dependency "httmultiparty", "~> 0.3.16"
   spec.add_dependency "commander", "~> 4.3"

--- a/lib/aptly_cli/version.rb
+++ b/lib/aptly_cli/version.rb
@@ -1,3 +1,3 @@
 module AptlyCli
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
If we have the developer gem dependencies in Gemfile they won't show up on RubyGems web page.

Note the missing Rubocop and simplecov

<img width="1155" alt="screen shot 2016-07-21 at 8 10 37 pm" src="https://cloud.githubusercontent.com/assets/538171/17045573/52ff57ea-4f7f-11e6-8b09-1245ed84c915.png">

Ill move those to aptly_cli.gemspec

Not sure if I can move 
gem "keyring", require: false, platform: :ruby_20
to aptly_cli.gemspec

http://guides.rubygems.org/specification-reference/

There is a 'platform' option we can use for ruby_20, but I don't see a option for setting require to false.

@msabramo we can just leave `keyring`  in Gemfile for now.  It won't show up on Rubygems though.
