### PR TITLE
Rakefile: Restart aptly_api_test Docker container

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ end
 
 desc "Start Aptly Docker container on port 8082"
 task :docker_run do
-  sh %{docker run -d -p 8082:8080 sepulworld/aptly_api_test /bin/sh -c "aptly api serve"}
+  sh %{docker run -d -p 8082:8080 --restart=always sepulworld/aptly_api_test /bin/sh -c "aptly api serve"}
 end
 
 desc "Show running Aptly process Docker stdout logs"


### PR DESCRIPTION
because I was finding that whenever I switched networks, the Docker
container was no longer running and then my tests would fail. This keeps
it running.

https://docs.docker.com/v1.8/reference/commandline/run/#restart-policies
