### PR TITLE
Test `${KEYRING}` feature

### DIFF
--- a/test/keyring.rb
+++ b/test/keyring.rb
@@ -1,0 +1,1 @@
+# So `require 'keyring'` doesn't fail


### PR DESCRIPTION
This gets coverage of `lib/aptly_command.rb` to 97.22%.
