### PR TITLE
Add --no-config option

### DIFF
--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -18,7 +18,9 @@ $debug = false
 global_option('-c', '--config FILE', 'Path to YAML config file') do |config_file|
   $config_file = config_file
 end
-
+global_option('--no-config', 'Don\'t try to read YAML config file') do |config_file|
+  $config_file = nil
+end
 global_option('-s', '--server SERVER', 'Host name or IP address of Aptly API server') do |server|
   $server = server
 end

--- a/lib/aptly_load.rb
+++ b/lib/aptly_load.rb
@@ -34,18 +34,23 @@ module AptlyCli
 
     # Configure through yaml file
     def configure_with(path_to_yaml_file)
-      begin
-        config = YAML.load(IO.read(path_to_yaml_file))
-      rescue Errno::ENOENT
-        @log.warn(
-          "YAML configuration file couldn\'t be found at " \
-           "#{path_to_yaml_file}. Using defaults.")
-        return @config
-      rescue Psych::SyntaxError
-        @log.warn(
-          'YAML configuration file contains invalid syntax. Using defaults.')
-        return @config
+      if path_to_yaml_file
+        begin
+          config = YAML.load(IO.read(path_to_yaml_file))
+        rescue Errno::ENOENT
+          @log.warn(
+            "YAML configuration file couldn\'t be found at " \
+             "#{path_to_yaml_file}. Using defaults.")
+          return @config
+        rescue Psych::SyntaxError
+          @log.warn(
+            'YAML configuration file contains invalid syntax. Using defaults.')
+          return @config
+        end
+      else
+        config = {}
       end
+
       configure(config)
     end
   end

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -17,7 +17,7 @@ end
 
 describe AptlyCli::AptlyCommand do
   it 'has a default config' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config)
     cmd.config[:proto].must_equal 'http'
     cmd.config[:server].must_equal '127.0.0.1'
@@ -26,7 +26,7 @@ describe AptlyCli::AptlyCommand do
 
   it 'accepts empty options and no config changes' do
     options = Options.new
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:proto].must_equal 'http'
     cmd.config[:server].must_equal '127.0.0.1'
@@ -40,7 +40,7 @@ describe AptlyCli::AptlyCommand do
     options.username = 'me'
     options.password = 'secret'
     options.debug = true
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:server].must_equal 'my-server'
     cmd.config[:port].must_equal 9000
@@ -52,7 +52,7 @@ describe AptlyCli::AptlyCommand do
   it 'can process an option with \'${PROMPT}\' in it' do
     options = Options.new
     options.username = '${PROMPT}'
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:username].must_equal 'zane'
   end
@@ -60,7 +60,7 @@ describe AptlyCli::AptlyCommand do
   it 'can process an option with \'${PROMPT_PASSWORD}\' in it' do
     options = Options.new
     options.username = '${PROMPT_PASSWORD}'
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:username].must_equal 'secret'
   end
@@ -80,7 +80,7 @@ describe AptlyCli::AptlyCommand do
       nil,
       ['Aptly API server at 127.0.0.1:8082', 'marc', 'secret'])
     Keyring.stub :new, keyring do
-      config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+      config = AptlyCli::AptlyLoad.new.configure_with(nil)
       cmd = AptlyCli::AptlyCommand.new(config, options)
       cmd.config[:username].must_equal 'marc'
       cmd.config[:password].must_equal 'secret'

--- a/test/test_aptly_file.rb
+++ b/test/test_aptly_file.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'aptly_cli'
 
 def post_test_file(location)
-  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  config = AptlyCli::AptlyLoad.new.configure_with(nil)
   file_api_setup = AptlyCli::AptlyFile.new(config)
   file_api_setup.file_post(
     file_uri: location.to_s,
@@ -27,7 +27,7 @@ describe AptlyCli::AptlyFile do
 end
 
 describe 'API GET files' do
-  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  config = AptlyCli::AptlyLoad.new.configure_with(nil)
   let(:file_api) { AptlyCli::AptlyFile.new(config) }
   post_test_file('/testdirfile') 
   
@@ -37,7 +37,7 @@ describe 'API GET files' do
 end
 
 describe 'API DELETE files' do
-  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  config = AptlyCli::AptlyLoad.new.configure_with(nil)
   let(:file_api) { AptlyCli::AptlyFile.new(config) }
   post_test_file('/testdirfiledelete') 
   
@@ -49,7 +49,7 @@ end
 
 
 describe "API POST package files" do
-  config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+  config = AptlyCli::AptlyLoad.new.configure_with(nil)
   let(:api_file) { AptlyCli::AptlyFile.new(config) }
   let(:data_for_not_found) { api_file.file_get('test_package_not_here') }
 

--- a/test/test_aptly_misc.rb
+++ b/test/test_aptly_misc.rb
@@ -23,7 +23,7 @@ describe AptlyCli::AptlyMisc do
   end
 
   describe 'API Get graph' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:misc_api) { AptlyCli::AptlyMisc.new(config) }
 
     def test_graph_request_for_SVG_returns_200 
@@ -36,7 +36,7 @@ describe AptlyCli::AptlyMisc do
   end
 
   describe 'API Get Version' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:misc_api) { AptlyCli::AptlyMisc.new(config) }
 
     def test_version_returns_valid

--- a/test/test_aptly_package.rb
+++ b/test/test_aptly_package.rb
@@ -9,7 +9,7 @@ describe AptlyCli::AptlyPackage do
   end
 
   describe "API List Package" do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:package_api) { AptlyCli::AptlyPackage.new(config) }
 
     def test_package_show

--- a/test/test_aptly_publish.rb
+++ b/test/test_aptly_publish.rb
@@ -9,7 +9,7 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API List Publish' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
@@ -40,7 +40,7 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Drop Publish' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
@@ -60,7 +60,7 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Publish Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
@@ -80,7 +80,7 @@ describe AptlyCli::AptlyPublish do
   end
 
   describe 'API Update Publish Point' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -8,7 +8,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Upload to Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
     let(:file_api) { AptlyCli::AptlyFile.new(config) }
 
@@ -26,7 +26,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Create Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_creation
@@ -42,7 +42,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Show Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_show
@@ -59,7 +59,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Package Query Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
     let(:file_api) { AptlyCli::AptlyFile.new(config) }
 
@@ -84,7 +84,7 @@ describe AptlyCli::AptlyRepo do
   end
   
   describe 'API List Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_list_repo_http_response
@@ -93,7 +93,7 @@ describe AptlyCli::AptlyRepo do
   end
   
   describe 'API Edit Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_edit_default_distribution
@@ -114,7 +114,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Delete Repo' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
 
     def test_repo_delete
@@ -128,7 +128,7 @@ describe AptlyCli::AptlyRepo do
   end
 
   describe 'API Upload to Repo, failure scenario' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api_fail) { AptlyCli::AptlyRepo.new(config) }
     let(:data) { repo_api_fail.repo_upload({ name: 'testrepo',
                                            dir: 'rockpackages',

--- a/test/test_aptly_snapshot.rb
+++ b/test/test_aptly_snapshot.rb
@@ -9,7 +9,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Delete Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
     let(:publish_api) { AptlyCli::AptlyPublish.new(config) }
 
@@ -51,7 +51,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Create and List Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_create
@@ -78,7 +78,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Update Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_update_name
@@ -112,7 +112,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Search Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_search_for_all_with_details
@@ -139,7 +139,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Diff Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_diff
@@ -156,7 +156,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Show Snapshot' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_show
@@ -169,7 +169,7 @@ describe AptlyCli::AptlySnapshot do
   end
 
   describe 'API Create Snapshot from Package Refs' do
-    config = AptlyCli::AptlyLoad.new.configure_with('/no/config')
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:snapshot_api) { AptlyCli::AptlySnapshot.new(config) }
 
     def test_snapshot_create_ref


### PR DESCRIPTION
This lets us get rid of `YAML configuration file couldn't be found at
/no/config. Using defaults.` warnings; especially when running the unit tests.

```
$ bundle exec rake test
/usr/local/Cellar/ruby/2.3.1/bin/ruby -I"lib:lib:test" -I"/Users/marca/dev/git-repos/aptly_cli/.bundle/gems/gems/rake-10.5.0/lib" "/Users/marca/dev/git-repos/aptly_cli/.bundle/gems/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/test_aptly_cli_configure.rb" "test/test_aptly_command.rb" "test/test_aptly_file.rb" "test/test_aptly_misc.rb" "test/test_aptly_package.rb" "test/test_aptly_publish.rb" "test/test_aptly_repo.rb" "test/test_aptly_snapshot.rb"
/Users/marca/dev/git-repos/aptly_cli/test/minitest_helper.rb:4:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
Run options: --seed 26736

.................................................................

Finished in 0.460966s, 141.0082 runs/s, 232.1212 assertions/s.

65 runs, 107 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/marca/dev/git-repos/aptly_cli/coverage. 636 / 658 LOC (96.66%) covered.
[Coveralls] Outside the CI environment, not sending data.
```
