### PR TITLE
Eliminate simplecov deprecation message

### DIFF
--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,10 +1,12 @@
 require 'coveralls'
 require 'simplecov'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter,
+  ]
+)
 
 SimpleCov.start do
   add_filter '/\.bundle/'


### PR DESCRIPTION
```
test/minitest_helper.rb:4:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```
