### PR TITLE
Fix repo_upload failure handling

### DIFF
--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -97,26 +97,20 @@ module AptlyCli
       case response.code
       when 404
         puts 'repository with such name does not exist'
+        return response
       end
 
       json_response = JSON.parse(response.body)
 
       unless json_response['FailedFiles'].empty?
-        begin
-        rescue StandardError => e
-          puts "Files that failed to upload... #{json_response['FailedFiles']}"
-          puts e
-        end
+        puts "Files that failed to upload... #{json_response['FailedFiles']}"
       end
 
       unless json_response['Report']['Warnings'].empty?
-        begin
-        rescue StandardError => e
-          puts "File upload warning message[s]...\
-               #{json_response['Report']['Warnings']}"
-          puts e
-        end
+        puts "File upload warning message[s]...\
+             #{json_response['Report']['Warnings']}"
       end
+
       return response
     end
   end


### PR DESCRIPTION
- a 404 response previously would output a message to stdout but then
  continue to try to parse JSON, which would fail.
- the `FailedFiles` and `Warnings` code never got executed because it
  was in `rescue` blocks that don't get triggered.
