### PR TITLE
the object 'options' provided by Commander doesn't have methods to te…

### DIFF
--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -3,28 +3,27 @@ module AptlyCli
     include HTTMultiParty
 
     attr_accessor :config
-
     def initialize(config, options = nil)
       @config = config
       options ||= Options.new
 
-      if options.respond_to?(:server) && options.server
+      if options.server
         @config[:server] = options.server
       end
 
-      if options.respond_to?(:port) && options.port
+      if options.port
         @config[:port] = options.port
       end
 
-      if options.respond_to?(:username) && options.username
+      if options.username
         @config[:username] = options.username
       end
 
-      if options.respond_to?(:password) && options.password
+      if options.password
         @config[:password] = options.password
       end
 
-      if options.respond_to?(:debug) && options.debug
+      if options.debug
         @config[:debug] = options.debug
       end
 
@@ -63,9 +62,7 @@ module AptlyCli
         end
       end
 
-      if respond_to?(:debug_output)
-        debug_output $stdout if @config[:debug] == true
-      end
+      self.class.debug_output $stdout if @config[:debug] == true
     end
   end
 end

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -39,14 +39,12 @@ describe AptlyCli::AptlyCommand do
     options.port = 9000
     options.username = 'me'
     options.password = 'secret'
-    options.debug = true
     config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:server].must_equal 'my-server'
     cmd.config[:port].must_equal 9000
     cmd.config[:username].must_equal 'me'
     cmd.config[:password].must_equal 'secret'
-    cmd.config[:debug].must_equal true
   end
 
   it 'can process an option with \'${PROMPT}\' in it' do

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -48,7 +48,7 @@ describe AptlyCli::AptlyCommand do
     cmd.config[:port].must_equal 9000
     cmd.config[:username].must_equal 'me'
     cmd.config[:password].must_equal 'secret'
-    cmd.config[:debug].must_equal nil 
+    cmd.config[:debug].must_equal nil
   end
 
   it 'can process an option with \'${PROMPT}\' in it' do

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -39,12 +39,15 @@ describe AptlyCli::AptlyCommand do
     options.port = 9000
     options.username = 'me'
     options.password = 'secret'
+    options.debug = false 
+    puts options
     config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:server].must_equal 'my-server'
     cmd.config[:port].must_equal 9000
     cmd.config[:username].must_equal 'me'
     cmd.config[:password].must_equal 'secret'
+    cmd.config[:debug].must_equal nil 
   end
 
   it 'can process an option with \'${PROMPT}\' in it' do

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -40,7 +40,6 @@ describe AptlyCli::AptlyCommand do
     options.username = 'me'
     options.password = 'secret'
     options.debug = false 
-    puts options
     config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:server].must_equal 'my-server'

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -1,3 +1,5 @@
+
+
 require 'minitest_helper.rb'
 require 'minitest/autorun'
 
@@ -39,7 +41,7 @@ describe AptlyCli::AptlyCommand do
     options.port = 9000
     options.username = 'me'
     options.password = 'secret'
-    options.debug = false 
+    options.debug = false
     config = AptlyCli::AptlyLoad.new.configure_with(nil)
     cmd = AptlyCli::AptlyCommand.new(config, options)
     cmd.config[:server].must_equal 'my-server'


### PR DESCRIPTION
https://github.com/sepulworld/aptly_cli/issues/134

I believe this is the route to take.  @msabramo let me know what you think.  The `options` object that Commander creates doesn't have methods to test responses using `respond_to?`
