### PR TITLE
upating ruby version to match supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ after_script:
 - rake docker_show_logs
 
 rvm:
-- 1.9.3
-- 2.2.0
-- 2.2.4
-- 2.3.0
+- 2.1.10
+- 2.2.5
+- 2.3.1
 
 deploy:
   provider: rubygems


### PR DESCRIPTION
Updating rvm environments to test against to match supported Ruby versions.  Removing Ruby 1.9.3 as it was [EOL](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/) in 2015 (over 1 year ago)
