### PR TITLE
Convert option.snapshots to Hash before passing to publish_update

### DIFF
--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -322,7 +322,7 @@ command :publish_update do |c|
   c.example 'description', 'aptly-cli publish_update --forceoverwrite --distribution precise'
   c.option '--prefix PREFIX', String, 'Publishing prefix, default root'
   c.option '--distribution DISTRIBUTION', String, 'Distribution name'
-  c.option '--snapshots SNAPSHOTS', String, 'When updating published snapshots, list of objects component/name seperated by space'
+  c.option '--snapshots SNAPSHOTS', Array, 'When updating published snapshots, list of objects component/name seperated by space'
   c.option '--forceoverwrite', 'When publishing, overwrite files in pool/ directory without notice'
   c.option '--gpg_skip', 'Don’t sign published repository'
   c.option '--gpg_batch', 'should be set if passing passphrase'
@@ -339,7 +339,7 @@ command :publish_update do |c|
                                                     :skip => options.gpg_skip, :batch => options.gpg_batch, :gpgKey => options.gpg_key,
                                                     :keyring => options.gpg_keyring, :secretKeyring => options.gpg_secret_keyring,
                                                     :passphrase => options.gpg_passphrase, :passphraseFile => options.gpg_passphrase_file,
-                                                    :snapshots => options.snapshots})
+                                                    :snapshots => Hash[*options.snapshots]})
   end
 end
 

--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -320,6 +320,7 @@ command :publish_update do |c|
   c.summary = 'Update published repository'
   c.description = 'Update published repository. If local repository has been published, published repository would be updated to match local repository contents. If snapshots have been been published, it is possible to switch each component to new snapshot'
   c.example 'description', 'aptly-cli publish_update --forceoverwrite --distribution precise'
+  c.example 'update snapshot', 'aptly-cli publish_update --snapshots testrepo_single_snap_to_pub,main  --prefix . --distribution=precise --gpg_skip'
   c.option '--prefix PREFIX', String, 'Publishing prefix, default root'
   c.option '--distribution DISTRIBUTION', String, 'Distribution name'
   c.option '--snapshots SNAPSHOTS', Array, 'When updating published snapshots, list of objects component/name seperated by space'

--- a/lib/aptly_cli/version.rb
+++ b/lib/aptly_cli/version.rb
@@ -1,3 +1,3 @@
 module AptlyCli
-  VERSION = '0.3.9'.freeze
+  VERSION = '0.3.10'.freeze
 end


### PR DESCRIPTION
Hi, I can't seem to get `publish_update` to work. With this patch applied I can run it like this: `aptly-cli publish_update --snapshots jessie-snapshot,main --prefix . --distribution=jessie`. I'm pretty sure I'm just too stupid to guess the correct syntax to make it work without the patch, but here is a pull request just in case. If I'm just not using it right, please tell me.
