### PR TITLE
Add new commands repo_package_add and repo_package_delete

### DIFF
--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -183,6 +183,34 @@ command :repo_list do |c|
   end
 end
 
+command :repo_package_add do |c|
+  c.syntax = 'aptly-cli repo_package_add [options]'
+  c.summary = 'Add existing package to local repository'
+  c.description = 'Add existing package to local repository'
+  c.example 'Add packages to local repository', 'aptly-cli repo_package_add --name megatronsoftware \'Pamd64 geoipupdate 2.0.0 87f1591307e50817\' \'Pi386 geoipupdate 2.0.0 87f1591307e50817\''
+  c.option '--name NAME', String, 'Local repository name, required'
+  c.action do |args, options|
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
+    puts aptly_command.repo_package_add({ :name => options.name }, args)
+  end
+end
+
+command :repo_package_delete do |c|
+  c.syntax = 'aptly-cli repo_package_delete [options]'
+  c.summary = 'Delete package from local repository'
+  c.description = 'Delete package from local repository'
+  c.example 'Delete packages from local repository', 'aptly-cli repo_package_delete --name megatronsoftware \'Pamd64 geoipupdate 2.0.0 87f1591307e50817\' \'Pi386 geoipupdate 2.0.0 87f1591307e50817\''
+  c.option '--name NAME', String, 'Local repository name, required'
+  c.action do |args, options|
+    config = AptlyCli::AptlyLoad.new.configure_with($config_file)
+    handle_global_options options
+    aptly_command = AptlyCli::AptlyRepo.new(config, options)
+    puts aptly_command.repo_package_delete({ :name => options.name }, args)
+  end
+end
+
 command :repo_package_query do |c|
   c.syntax = 'aptly-cli repo_package_query [options]'
   c.summary = 'List all packages or search on repo contents, requires --name'

--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -51,6 +51,32 @@ module AptlyCli
       self.class.get(uri)
     end
 
+    def repo_package_add(repo_options = { name: nil }, packages)
+      if repo_options[:name].nil?
+        raise ArgumentError.new('Must pass a repository name')
+      end
+
+      uri = '/repos/' + repo_options[:name] + '/packages'
+      self.class.post(
+        uri,
+        body: { :PackageRefs => packages }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    def repo_package_delete(repo_options = { name: nil }, packages)
+      if repo_options[:name].nil?
+        raise ArgumentError.new('Must pass a repository name')
+      end
+
+      uri = '/repos/' + repo_options[:name] + '/packages'
+      self.class.delete(
+        uri,
+        body: { :PackageRefs => packages }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
     def repo_package_query(repo_options = { name: nil, query: nil,
                                             with_deps: false,
                                             format: nil })

--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -51,28 +51,28 @@ module AptlyCli
       self.class.get(uri)
     end
 
-    def repo_package_add(repo_options = { name: nil }, packages)
-      if repo_options[:name].nil?
+    def repo_package_add(repo_options, packages)
+      if !repo_options.is_a?(Hash) || repo_options[:name].nil?
         raise ArgumentError.new('Must pass a repository name')
       end
 
       uri = '/repos/' + repo_options[:name] + '/packages'
       self.class.post(
         uri,
-        body: { :PackageRefs => packages }.to_json,
+        body: { PackageRefs: packages }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
     end
 
-    def repo_package_delete(repo_options = { name: nil }, packages)
-      if repo_options[:name].nil?
+    def repo_package_delete(repo_options, packages)
+      if !repo_options.is_a?(Hash) || repo_options[:name].nil?
         raise ArgumentError.new('Must pass a repository name')
       end
 
       uri = '/repos/' + repo_options[:name] + '/packages'
       self.class.delete(
         uri,
-        body: { :PackageRefs => packages }.to_json,
+        body: { PackageRefs: packages }.to_json,
         headers: { 'Content-Type' => 'application/json' }
       )
     end

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -139,9 +139,9 @@ describe AptlyCli::AptlyRepo do
                            DefaultDistribution: 'precisepackageaddtest',
                            DefaultComponent: nil)
       repo_api.repo_create(name: 'testrepotoaddto',
-        comment: 'testing package add to repo',
-        DefaultDistribution: 'precisepackageaddtest',
-        DefaultComponent: nil)
+                           comment: 'testing package add to repo',
+                           DefaultDistribution: 'precisepackageaddtest',
+                           DefaultComponent: nil)
       repo_api.repo_upload(name: 'testrepowithpackage',
                            dir: 'testdir2/',
                            file: 'test_1.0_amd64.deb')
@@ -149,41 +149,39 @@ describe AptlyCli::AptlyRepo do
                                         query: 'geoipupdate',
                                         with_deps: true,
                                         format: nil)
-      res = repo_api.repo_package_add({ name: 'testrepotoaddto' }, [ res.parsed_response.first.to_s ])
+      res = repo_api.repo_package_add({ name: 'testrepotoaddto' }, [res.parsed_response.first.to_s])
       assert_equal res.request.uri.to_s,
                    'http://127.0.0.1:8082/api/repos/testrepotoaddto/packages'
       assert_equal res.parsed_response,
-                   {
-                     'Name' => 'testrepotoaddto',
-                     'Comment' => 'testing package add to repo',
-                     'DefaultDistribution' => 'precisepackageaddtest',
-                     'DefaultComponent' => ''
-                   }
+                   'Name' => 'testrepotoaddto',
+                   'Comment' => 'testing package add to repo',
+                   'DefaultDistribution' => 'precisepackageaddtest',
+                   'DefaultComponent' => ''
     end
 
     def test_package_add_with_no_name
       repo_api.repo_delete(name: 'testrepowithpackage',
-        force: true)
+                           force: true)
       file_api.file_post(file_uri: '/testdir2',
-        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
-        local_file: 'test/fixtures/test_1.0_amd64.deb')
+                         package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+                         local_file: 'test/fixtures/test_1.0_amd64.deb')
       repo_api.repo_create(name: 'testrepowithpackage',
-        comment: 'testing package add to repo',
-        DefaultDistribution: 'precisepackageaddtest',
-        DefaultComponent: nil)
+                           comment: 'testing package add to repo',
+                           DefaultDistribution: 'precisepackageaddtest',
+                           DefaultComponent: nil)
       repo_api.repo_create(name: 'testrepotoaddto',
-        comment: 'testing package add to repo',
-        DefaultDistribution: 'precisepackageaddtest',
-        DefaultComponent: nil)
+                           comment: 'testing package add to repo',
+                           DefaultDistribution: 'precisepackageaddtest',
+                           DefaultComponent: nil)
       repo_api.repo_upload(name: 'testrepowithpackage',
-        dir: 'testdir2/',
-        file: 'test_1.0_amd64.deb')
+                           dir: 'testdir2/',
+                           file: 'test_1.0_amd64.deb')
       res = repo_api.repo_package_query(name: 'testrepowithpackage',
-        query: 'geoipupdate',
-        with_deps: true,
-        format: nil)
+                                        query: 'geoipupdate',
+                                        with_deps: true,
+                                        format: nil)
       assert_raises ArgumentError do
-        repo_api.repo_package_add({}, [ res.parsed_response.first.to_s ])
+        repo_api.repo_package_add({}, [res.parsed_response.first.to_s])
       end
     end
   end
@@ -195,52 +193,50 @@ describe AptlyCli::AptlyRepo do
 
     def test_package_delete_with_name
       repo_api.repo_delete(name: 'testrepowithpackage',
-        force: true)
+                           force: true)
       file_api.file_post(file_uri: '/testdir2',
-        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
-        local_file: 'test/fixtures/test_1.0_amd64.deb')
+                         package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+                         local_file: 'test/fixtures/test_1.0_amd64.deb')
       repo_api.repo_create(name: 'testrepotodeletefrom',
-        comment: 'testing package delete from repo',
-        DefaultDistribution: 'precisepackagedeletetest',
-        DefaultComponent: nil)
+                           comment: 'testing package delete from repo',
+                           DefaultDistribution: 'precisepackagedeletetest',
+                           DefaultComponent: nil)
       repo_api.repo_upload(name: 'testrepotodeletefrom',
-        dir: 'testdir2/',
-        file: 'test_1.0_amd64.deb')
+                           dir: 'testdir2/',
+                           file: 'test_1.0_amd64.deb')
       res = repo_api.repo_package_query(name: 'testrepotodeletefrom',
-        query: 'geoipupdate',
-        with_deps: true,
-        format: nil)
-      res = repo_api.repo_package_delete({ name: 'testrepotodeletefrom' }, [ res.parsed_response.first.to_s ])
+                                        query: 'geoipupdate',
+                                        with_deps: true,
+                                        format: nil)
+      res = repo_api.repo_package_delete({ name: 'testrepotodeletefrom' }, [res.parsed_response.first.to_s])
       assert_equal res.request.uri.to_s,
         'http://127.0.0.1:8082/api/repos/testrepotodeletefrom/packages'
       assert_equal res.parsed_response,
-        {
-          'Name' => 'testrepotodeletefrom',
-          'Comment' => 'testing package delete from repo',
-          'DefaultDistribution' => 'precisepackagedeletetest',
-          'DefaultComponent' => ''
-        }
+                   'Name' => 'testrepotodeletefrom',
+                   'Comment' => 'testing package delete from repo',
+                   'DefaultDistribution' => 'precisepackagedeletetest',
+                   'DefaultComponent' => ''
     end
 
     def test_package_delete_with_no_name
       repo_api.repo_delete(name: 'testrepowithpackage',
-        force: true)
+                           force: true)
       file_api.file_post(file_uri: '/testdir2',
-        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
-        local_file: 'test/fixtures/test_1.0_amd64.deb')
+                         package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+                         local_file: 'test/fixtures/test_1.0_amd64.deb')
       repo_api.repo_create(name: 'testrepotodeletefrom',
-        comment: 'testing package delete from repo',
-        DefaultDistribution: 'precisepackagedeletetest',
-        DefaultComponent: nil)
+                           comment: 'testing package delete from repo',
+                           DefaultDistribution: 'precisepackagedeletetest',
+                           DefaultComponent: nil)
       repo_api.repo_upload(name: 'testrepotodeletefrom',
-        dir: 'testdir2/',
-        file: 'test_1.0_amd64.deb')
+                           dir: 'testdir2/',
+                           file: 'test_1.0_amd64.deb')
       res = repo_api.repo_package_query(name: 'testrepotodeletefrom',
-        query: 'geoipupdate',
-        with_deps: true,
-        format: nil)
+                                        query: 'geoipupdate',
+                                        with_deps: true,
+                                        format: nil)
       assert_raises ArgumentError do
-        repo_api.repo_package_delete({}, [ res.parsed_response.first.to_s ])
+        repo_api.repo_package_delete({}, [res.parsed_response.first.to_s])
       end
     end
   end

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -123,6 +123,128 @@ describe AptlyCli::AptlyRepo do
     end
   end
 
+  describe 'API Package Add To Repo' do
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
+    let(:file_api) { AptlyCli::AptlyFile.new(config) }
+
+    def test_package_add_with_name
+      repo_api.repo_delete(name: 'testrepowithpackage',
+                           force: true)
+      file_api.file_post(file_uri: '/testdir2',
+                         package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+                         local_file: 'test/fixtures/test_1.0_amd64.deb')
+      repo_api.repo_create(name: 'testrepowithpackage',
+                           comment: 'testing package add to repo',
+                           DefaultDistribution: 'precisepackageaddtest',
+                           DefaultComponent: nil)
+      repo_api.repo_create(name: 'testrepotoaddto',
+        comment: 'testing package add to repo',
+        DefaultDistribution: 'precisepackageaddtest',
+        DefaultComponent: nil)
+      repo_api.repo_upload(name: 'testrepowithpackage',
+                           dir: 'testdir2/',
+                           file: 'test_1.0_amd64.deb')
+      res = repo_api.repo_package_query(name: 'testrepowithpackage',
+                                        query: 'geoipupdate',
+                                        with_deps: true,
+                                        format: nil)
+      res = repo_api.repo_package_add({ name: 'testrepotoaddto' }, [ res.parsed_response.first.to_s ])
+      assert_equal res.request.uri.to_s,
+                   'http://127.0.0.1:8082/api/repos/testrepotoaddto/packages'
+      assert_equal res.parsed_response,
+                   {
+                     'Name' => 'testrepotoaddto',
+                     'Comment' => 'testing package add to repo',
+                     'DefaultDistribution' => 'precisepackageaddtest',
+                     'DefaultComponent' => ''
+                   }
+    end
+
+    def test_package_add_with_no_name
+      repo_api.repo_delete(name: 'testrepowithpackage',
+        force: true)
+      file_api.file_post(file_uri: '/testdir2',
+        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+        local_file: 'test/fixtures/test_1.0_amd64.deb')
+      repo_api.repo_create(name: 'testrepowithpackage',
+        comment: 'testing package add to repo',
+        DefaultDistribution: 'precisepackageaddtest',
+        DefaultComponent: nil)
+      repo_api.repo_create(name: 'testrepotoaddto',
+        comment: 'testing package add to repo',
+        DefaultDistribution: 'precisepackageaddtest',
+        DefaultComponent: nil)
+      repo_api.repo_upload(name: 'testrepowithpackage',
+        dir: 'testdir2/',
+        file: 'test_1.0_amd64.deb')
+      res = repo_api.repo_package_query(name: 'testrepowithpackage',
+        query: 'geoipupdate',
+        with_deps: true,
+        format: nil)
+      assert_raises ArgumentError do
+        repo_api.repo_package_add({}, [ res.parsed_response.first.to_s ])
+      end
+    end
+  end
+
+  describe 'API Package Delete From Repo' do
+    config = AptlyCli::AptlyLoad.new.configure_with(nil)
+    let(:repo_api) { AptlyCli::AptlyRepo.new(config) }
+    let(:file_api) { AptlyCli::AptlyFile.new(config) }
+
+    def test_package_delete_with_name
+      repo_api.repo_delete(name: 'testrepowithpackage',
+        force: true)
+      file_api.file_post(file_uri: '/testdir2',
+        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+        local_file: 'test/fixtures/test_1.0_amd64.deb')
+      repo_api.repo_create(name: 'testrepotodeletefrom',
+        comment: 'testing package delete from repo',
+        DefaultDistribution: 'precisepackagedeletetest',
+        DefaultComponent: nil)
+      repo_api.repo_upload(name: 'testrepotodeletefrom',
+        dir: 'testdir2/',
+        file: 'test_1.0_amd64.deb')
+      res = repo_api.repo_package_query(name: 'testrepotodeletefrom',
+        query: 'geoipupdate',
+        with_deps: true,
+        format: nil)
+      res = repo_api.repo_package_delete({ name: 'testrepotodeletefrom' }, [ res.parsed_response.first.to_s ])
+      assert_equal res.request.uri.to_s,
+        'http://127.0.0.1:8082/api/repos/testrepotodeletefrom/packages'
+      assert_equal res.parsed_response,
+        {
+          'Name' => 'testrepotodeletefrom',
+          'Comment' => 'testing package delete from repo',
+          'DefaultDistribution' => 'precisepackagedeletetest',
+          'DefaultComponent' => ''
+        }
+    end
+
+    def test_package_delete_with_no_name
+      repo_api.repo_delete(name: 'testrepowithpackage',
+        force: true)
+      file_api.file_post(file_uri: '/testdir2',
+        package: 'testdir2/fixtures/geoipupdate_2.0.0_amd64.deb',
+        local_file: 'test/fixtures/test_1.0_amd64.deb')
+      repo_api.repo_create(name: 'testrepotodeletefrom',
+        comment: 'testing package delete from repo',
+        DefaultDistribution: 'precisepackagedeletetest',
+        DefaultComponent: nil)
+      repo_api.repo_upload(name: 'testrepotodeletefrom',
+        dir: 'testdir2/',
+        file: 'test_1.0_amd64.deb')
+      res = repo_api.repo_package_query(name: 'testrepotodeletefrom',
+        query: 'geoipupdate',
+        with_deps: true,
+        format: nil)
+      assert_raises ArgumentError do
+        repo_api.repo_package_delete({}, [ res.parsed_response.first.to_s ])
+      end
+    end
+  end
+
   describe 'API Package Query Repo' do
     config = AptlyCli::AptlyLoad.new.configure_with(nil)
     let(:repo_api) { AptlyCli::AptlyRepo.new(config) }

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -210,7 +210,7 @@ describe AptlyCli::AptlyRepo do
                                         format: nil)
       res = repo_api.repo_package_delete({ name: 'testrepotodeletefrom' }, [res.parsed_response.first.to_s])
       assert_equal res.request.uri.to_s,
-        'http://127.0.0.1:8082/api/repos/testrepotodeletefrom/packages'
+                   'http://127.0.0.1:8082/api/repos/testrepotodeletefrom/packages'
       assert_equal res.parsed_response,
                    'Name' => 'testrepotodeletefrom',
                    'Comment' => 'testing package delete from repo',


### PR DESCRIPTION
This introduces `repo_package_add` and `repo_package_delete`, which can be used to add (existing) packages to repositories and delete packages from repositories.
