### PR TITLE
install only aptly-cli

### DIFF
--- a/aptly_cli.gemspec
+++ b/aptly_cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir                = "bin"
-  spec.executables           = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.executables           = "aptly-cli" 
   spec.require_paths         = ["lib"]
   spec.required_ruby_version = '>= 2.0.0'
 

--- a/lib/aptly_cli/version.rb
+++ b/lib/aptly_cli/version.rb
@@ -1,3 +1,3 @@
 module AptlyCli
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
We were installing console, setup and aptly-cli. We should only be installing aptly-cli. console and setup are for local development only.