### PR TITLE
Remove MultiHTTParty, and use HTTParty directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ after_script:
 - rake docker_show_logs
 
 rvm:
-- 2.1.10
-- 2.2.5
-- 2.3.1
+- 2.3.8
+- 2.4.5
+- 2.5.3
+- 2.6.1
 
 deploy:
   provider: rubygems

--- a/README.md
+++ b/README.md
@@ -257,4 +257,3 @@ rake test                  # Run tests
 
 - [ruby-aptly](https://github.com/ryanuber/ruby-aptly) - Ruby client library
 - [aptly-web-ui](https://github.com/sdumetz/aptly-web-ui) - Web interface for aptly (JavaScript, React, Redux)
-- [debweb](https://github.com/AutogrowSystems/debweb) - Another web interface (Ruby on Rails)

--- a/aptly_cli.gemspec
+++ b/aptly_cli.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "rubocop"
 
-  spec.add_dependency "httmultiparty", "~> 0.3.16"
-  spec.add_dependency "httparty", "~> 0.13.0"
+  spec.add_dependency('httparty', '>= 0.16.2')
   spec.add_dependency "commander", "~> 4.3"
 end

--- a/bin/aptly-cli
+++ b/bin/aptly-cli
@@ -501,7 +501,7 @@ command :graph do |c|
   c.syntax = 'aptly-cli graph [options]'
   c.summary = 'Download an svg or png graph of repository layout'
   c.description = 'Download a graph of repository layout.  Current options are "svg" and "png"'
-  c.example 'description', 'aptly-cli graph png > ~/repo_graph.png'
+  c.example 'description', 'aptly-cli graph --type png > ~/repo_graph.png'
   c.option '--type GRAPH_TYPE', String, 'Type of graph to download, present options are png or svg'
   c.action do |args, options|
     config = AptlyCli::AptlyLoad.new.configure_with($config_file)

--- a/lib/aptly_cli.rb
+++ b/lib/aptly_cli.rb
@@ -1,5 +1,5 @@
 require 'aptly_cli/version'
-require 'httmultiparty'
+require 'httparty'
 
 # Initializing
 module AptlyCli

--- a/lib/aptly_cli/version.rb
+++ b/lib/aptly_cli/version.rb
@@ -1,3 +1,3 @@
 module AptlyCli
-  VERSION = '0.4.2'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/lib/aptly_command.rb
+++ b/lib/aptly_command.rb
@@ -1,6 +1,6 @@
 module AptlyCli
   class AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     attr_accessor :config
     def initialize(config, options = nil)

--- a/lib/aptly_file.rb
+++ b/lib/aptly_file.rb
@@ -1,7 +1,7 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 
 module AptlyCli
   # Uploading file into Aptly
@@ -10,7 +10,8 @@ module AptlyCli
 
     def file_dir
       uri = '/files'
-      self.class.get uri
+      response = self.class.get uri
+      response.parsed_response
     end
 
     def file_get(file_uri)
@@ -19,20 +20,24 @@ module AptlyCli
             else
               '/files/' + file_uri
             end
-      self.class.get uri
+      response = self.class.get uri
+      response.parsed_response
     end
 
     def file_delete(file_uri)
       uri = '/files' + file_uri
-      self.class.delete uri
+      response = self.class.delete uri
+      response.parsed_response
     end
 
     def file_post(post_options = {})
       api_file_uri = '/files' + post_options[:file_uri].to_s
-      self.class.post(api_file_uri,
-                      query: {
+      response = self.class.post(api_file_uri,
+                      body: {
                         package: post_options[:package],
-                        file: File.new(post_options[:local_file]) })
+                        file: File.new(post_options[:local_file])
+                      })
+      response.parsed_response
     end
   end
 end

--- a/lib/aptly_misc.rb
+++ b/lib/aptly_misc.rb
@@ -1,13 +1,13 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 require 'json'
 
 module AptlyCli
   # Misc Aptly Class
   class AptlyMisc < AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     def get_graph(extension)
       uri = "/graph.#{extension}"
@@ -16,7 +16,8 @@ module AptlyCli
 
     def get_version
       uri = '/version'
-      self.class.get(uri)
+      response = self.class.get(uri)
+      response.parsed_response
     end
   end
 end

--- a/lib/aptly_package.rb
+++ b/lib/aptly_package.rb
@@ -1,13 +1,13 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 require 'json'
 
 module AptlyCli
   # Aptly Package API
   class AptlyPackage < AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     def package_show(package_key)
       uri = "/packages/#{package_key}"

--- a/lib/aptly_publish.rb
+++ b/lib/aptly_publish.rb
@@ -1,13 +1,13 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 require 'json'
 
 module AptlyCli
   # :nodoc:
   class AptlyPublish < AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     @@available_gpg_options = [:skip, :batch, :gpgKey, :keyring, :secretKeyring,
                               :passphrase, :passphraseFile]
@@ -92,8 +92,8 @@ module AptlyCli
 
       @body_json = @body.to_json
 
-      self.class.post(uri, headers: { 'Content-Type' => 'application/json' },
-                           body: @body_json)
+      self.class.post(uri, :headers => { 'Content-Type' => 'application/json' },
+                           :body => @body_json)
     end
 
     def publish_update(publish_options={})
@@ -118,8 +118,8 @@ module AptlyCli
       uri += "/#{publish_options[:distribution]}"
 
       @body_json = @body.to_json
-      self.class.put(uri, headers: { 'Content-Type' => 'application/json' },
-                          body: @body_json)
+      self.class.put(uri, :headers =>  { 'Content-Type' => 'application/json' },
+                          :body => @body_json)
     end
   end
 end

--- a/lib/aptly_repo.rb
+++ b/lib/aptly_repo.rb
@@ -1,14 +1,14 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 require 'json'
 require 'uri'
 
 module AptlyCli
   # Aptly class to work with Repo API
   class AptlyRepo < AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     def repo_create(repo_options = { name: nil,
                                      comment: nil,
@@ -20,11 +20,11 @@ module AptlyCli
       default_distribution = repo_options[:DefaultDistribution]
       default_component = repo_options[:DefaultComponent]
       self.class.post(uri,
-                      query:
+                      :body => 
                       { 'Name' => name, 'Comment' => comment,
                         'DefaultDistribution' => default_distribution,
                         'DefaultComponent' => default_component }.to_json,
-                      headers: { 'Content-Type' => 'application/json' })
+                      :headers => { 'Content-Type' => 'application/json' })
     end
 
     def repo_delete(repo_options = { name: nil, force: nil })
@@ -42,8 +42,8 @@ module AptlyCli
         repo_value = v
       end
 
-      self.class.put(uri, query: { repo_option => repo_value }.to_json,
-                          headers: { 'Content-Type' => 'application/json' })
+      self.class.put(uri, :body => { repo_option => repo_value }.to_json,
+                          :headers => { 'Content-Type' => 'application/json' })
     end
 
     def repo_list
@@ -59,8 +59,8 @@ module AptlyCli
       uri = '/repos/' + repo_options[:name] + '/packages'
       self.class.post(
         uri,
-        body: { PackageRefs: packages }.to_json,
-        headers: { 'Content-Type' => 'application/json' }
+        :body => { PackageRefs: packages }.to_json,
+        :headers => { 'Content-Type' => 'application/json' }
       )
     end
 
@@ -72,8 +72,8 @@ module AptlyCli
       uri = '/repos/' + repo_options[:name] + '/packages'
       self.class.delete(
         uri,
-        body: { PackageRefs: packages }.to_json,
-        headers: { 'Content-Type' => 'application/json' }
+        :body => { PackageRefs: packages }.to_json,
+        :headers => { 'Content-Type' => 'application/json' }
       )
     end
 

--- a/lib/aptly_snapshot.rb
+++ b/lib/aptly_snapshot.rb
@@ -1,13 +1,13 @@
 require 'aptly_cli/version'
 require 'aptly_command'
 require 'aptly_load'
-require 'httmultiparty'
+require 'httparty'
 require 'json'
 
 module AptlyCli
   # Aptly class to work with Snapshot API
   class AptlySnapshot < AptlyCommand
-    include HTTMultiParty
+    include HTTParty
 
     def snapshot_delete(name, force=nil)
       uri = "/snapshots/#{name}"
@@ -25,10 +25,10 @@ module AptlyCli
       # Build uri to create snapshot, requires name of snap and name of repo
       uri = "/repos/#{repo}/" + 'snapshots'
 
-      self.class.post(uri, query:
+      self.class.post(uri, :body => 
                       { 'Name' => name,
                         'Description' => description }.to_json,
-                           headers: { 'Content-Type' => 'application/json' })
+                           :headers => { 'Content-Type' => 'application/json' })
     end
 
     def snapshot_create_ref(name, description=nil,
@@ -36,10 +36,10 @@ module AptlyCli
       uri = '/snapshots'
       begin
         self.class.post(uri,
-                        query: { 'Name' => name, 'Description' => description,
+                        :body => { 'Name' => name, 'Description' => description,
                                  'SourceSnapshots' => sourcesnapshots,
                                  'PackageRefs' => packagerefs }.to_json,
-                        headers: { 'Content-Type' => 'application/json' })
+                        :headers => { 'Content-Type' => 'application/json' })
       rescue HTTParty::Error => e
         return e
       end
@@ -83,7 +83,7 @@ module AptlyCli
       @query[:Description] = description unless description.nil?
       @query_json = @query.to_json
       begin
-        self.class.put(uri, query: @query_json, headers:
+        self.class.put(uri, :body => @query_json, :headers =>
                        { 'Content-Type' => 'application/json' })
       rescue HTTParty::Error => e
         puts e

--- a/test/test_aptly_command.rb
+++ b/test/test_aptly_command.rb
@@ -1,5 +1,3 @@
-
-
 require 'minitest_helper.rb'
 require 'minitest/autorun'
 
@@ -48,7 +46,7 @@ describe AptlyCli::AptlyCommand do
     cmd.config[:port].must_equal 9000
     cmd.config[:username].must_equal 'me'
     cmd.config[:password].must_equal 'secret'
-    cmd.config[:debug].must_equal nil
+    assert_nil cmd.config[:debug]
   end
 
   it 'handles the "debug" option' do

--- a/test/test_aptly_file.rb
+++ b/test/test_aptly_file.rb
@@ -14,7 +14,7 @@ end
 
 describe AptlyCli::AptlyFile do
   it 'must include httparty methods' do
-    AptlyCli::AptlyFile.must_include HTTMultiParty
+    AptlyCli::AptlyFile.must_include HTTParty
   end
 
   it 'must have a default server API URL endpoint defined' do
@@ -36,9 +36,9 @@ describe 'API GET files' do
   end
 
   def test_file_get_no_file_uri
-    assert_equal '200', file_api.file_get('/').code.to_s
+    assert_includes file_api.file_get('/'), "testdirfile"
   ensure
-    assert_equal '200', file_api.file_dir.code.to_s
+    assert_includes file_api.file_dir, "testdirfile"
   end
 end
 
@@ -72,7 +72,7 @@ describe "API POST package files" do
   end
 
   it 'must parse the api response from JSON to Array' do
-    api_file.file_get('test').must_be_instance_of Array 
+    api_file.file_get('test').must_be_instance_of Array
   end
 
   it 'must parse the api response from JSON to Array' do

--- a/test/test_aptly_misc.rb
+++ b/test/test_aptly_misc.rb
@@ -5,7 +5,7 @@ require 'aptly_cli'
 
 describe AptlyCli::AptlyMisc do
   it 'must include httparty methods' do
-    AptlyCli::AptlyMisc.must_include HTTMultiParty
+    AptlyCli::AptlyMisc.must_include HTTParty
   end
 
   describe 'Test if config contains username' do

--- a/test/test_aptly_package.rb
+++ b/test/test_aptly_package.rb
@@ -5,7 +5,7 @@ require 'aptly_cli'
 
 describe AptlyCli::AptlyPackage do
   it "must include httparty methods" do
-    AptlyCli::AptlyPackage.must_include HTTMultiParty
+    AptlyCli::AptlyPackage.must_include HTTParty
   end
 
   describe "API List Package" do

--- a/test/test_aptly_publish.rb
+++ b/test/test_aptly_publish.rb
@@ -5,7 +5,7 @@ require 'aptly_cli'
 
 describe AptlyCli::AptlyPublish do
   it 'must include httparty methods' do
-    AptlyCli::AptlyPublish.must_include HTTMultiParty
+    AptlyCli::AptlyPublish.must_include HTTParty
   end
 
   describe 'API List Publish' do
@@ -32,9 +32,9 @@ describe AptlyCli::AptlyPublish do
         sourcekind: 'snapshot', distribution: 'publishlisttest2',
         architectures: %w(amd64 i386),
         skip: true)
-      assert_includes publish_api.publish_list.to_s,
+      assert_includes publish_api.publish_list.parsed_response.to_s,
                       '"Distribution"=>"publishlisttest1"'
-      assert_includes publish_api.publish_list.to_s,
+      assert_includes publish_api.publish_list.parsed_response.to_s,
                       '"Distribution"=>"publishlisttest2"'
     end
   end
@@ -74,7 +74,7 @@ describe AptlyCli::AptlyPublish do
         sourcekind: 'snapshot', distribution: 'precisetest',
         architectures: ['amd64'],
         component: 'main',
-        skip: true).to_s,
+        skip: true).parsed_response.to_s,
                       '{"Architectures"=>["amd64"], "Distribution"=>"precisetest",'
     end
   end
@@ -96,12 +96,12 @@ describe AptlyCli::AptlyPublish do
                       'SourceKind' => 'snapshot',
                       'Sources' => [{ 'Component' => 'main',
                                        'Name' => 'testrepo_single_snap_to_pub' }],
-                      'Storage' => '' }).to_s,
+                                       'Storage' => '' }).to_s,
                    publish_api.publish_repo(
                      ['main/testrepo_single_snap_to_pub'],
                      sourcekind: 'snapshot', distribution: 'precisetest3',
                      architectures: %w(amd64 i386),
-                     skip: true).to_s
+                     skip: true).parsed_response.to_s
     end
 
     def test_publish_update_success_multiple_repos
@@ -120,7 +120,7 @@ describe AptlyCli::AptlyPublish do
       assert_includes publish_api.publish_update(
         snapshots: { testrepo_snap_to_update_pub_1: 'main', testrepo_snap_to_update_pub_2: 'main2' },
         distribution: 'precisetest2',
-        forceoverwrite: true, skip: true).to_s,
+        forceoverwrite: true, skip: true).parsed_response.to_s,
                       '{"Component"=>"main", "Name"=>"testrepo_snap_to_update_pub_1"'.to_s
     end
 
@@ -145,13 +145,13 @@ describe AptlyCli::AptlyPublish do
         prefix: 'testrepo_snap_to_update_pub_prefix',
         distribution: 'precisetest2',
         forceoverwrite: true, skip: true).to_s,
-                      '{"Component"=>"main2", "Name"=>"testrepo_snap_to_update_pub_2"'.to_s
+                      '{"Component":"main2","Name":"testrepo_snap_to_update_pub_2"'.to_s
       resp = publish_api.publish_drop(
         prefix: 'testrepo_snap_to_update_pub_prefix',
         distribution: 'precisetest2',
       )
       assert_equal resp.code, 200
-      assert_equal resp.to_s, '{}'
+      assert_equal resp.parsed_response.to_s, "{}"
     end
   end
 end

--- a/test/test_aptly_repo.rb
+++ b/test/test_aptly_repo.rb
@@ -4,7 +4,7 @@ require 'aptly_cli'
 
 describe AptlyCli::AptlyRepo do
   it 'must include httparty methods' do
-    AptlyCli::AptlyRepo.must_include HTTMultiParty
+    AptlyCli::AptlyRepo.must_include HTTParty
   end
 
   describe 'API Upload to Repo' do
@@ -19,7 +19,7 @@ describe AptlyCli::AptlyRepo do
       assert_includes repo_api.repo_upload(
         name: 'testrepo',
         dir: 'testdir/',
-        file: 'test_1.0_amd64.deb').to_s,
+        file: 'test_1.0_amd64.deb').parsed_response.to_s,
         '{"FailedFiles"=>[], "Report"=>{"Warnings"=>[], "Added"=>'\
         '["geoipupdate_2.0.0_amd64 added"], "Removed"=>[]}}'
     end
@@ -84,7 +84,7 @@ describe AptlyCli::AptlyRepo do
       assert_includes repo_api.repo_create(name: 'testrepocreate',
                            comment: 'testing repo creation',
                            DefaultDistribution: 'precisecreatetest',
-                           DefaultComponent: nil).to_s,
+                           DefaultComponent: nil).parsed_response.to_s,
                            '{"Name"=>"testrepocreate", "Comment"=>"testing repo creation", '\
                            '"DefaultDistribution"=>"precisecreatetest", "DefaultComponent"=>""}'
     end
@@ -101,7 +101,7 @@ describe AptlyCli::AptlyRepo do
                            comment: 'testing repo show',
                            DefaultDistribution: 'preciseshowtest',
                            DefaultComponent: nil)
-      assert_includes repo_api.repo_show('testrepotoshow').to_s,
+      assert_includes repo_api.repo_show('testrepotoshow').parsed_response.to_s,
         '{"Name"=>"testrepotoshow", "Comment"=>"testing repo show", '\
         '"DefaultDistribution"=>"preciseshowtest", "DefaultComponent"=>""}'
     ensure
@@ -115,7 +115,7 @@ describe AptlyCli::AptlyRepo do
                            comment: 'testing repo show',
                            DefaultDistribution: 'preciseshowtest',
                            DefaultComponent: nil)
-      assert_includes repo_api.repo_show(nil).to_s,
+      assert_includes repo_api.repo_show(nil).parsed_response.to_s,
                       '{"Name"=>"testrepotoshow", '\
                       '"Comment"=>"testing repo show", '\
                       '"DefaultDistribution"=>"preciseshowtest", '\
@@ -337,7 +337,7 @@ describe AptlyCli::AptlyRepo do
 
       assert_includes repo_api.repo_edit(
         'testrepoedit',
-        DefaultDistribution: 'preciseeditdistnew').to_s,
+        DefaultDistribution: 'preciseeditdistnew').parsed_response.to_s,
         '{"Name"=>"testrepoedit", "Comment"=>"testing repo edit distro name", '\
         '"DefaultDistribution"=>"preciseeditdistnew", '\
         '"DefaultComponent"=>""}'

--- a/test/test_aptly_snapshot.rb
+++ b/test/test_aptly_snapshot.rb
@@ -5,7 +5,7 @@ require 'aptly_cli'
 
 describe AptlyCli::AptlySnapshot do
   it 'must include httparty methods' do
-    AptlyCli::AptlySnapshot.must_include HTTMultiParty
+    AptlyCli::AptlySnapshot.must_include HTTParty
   end
 
   describe 'API Delete Snapshot' do
@@ -38,7 +38,7 @@ describe AptlyCli::AptlySnapshot do
     def test_that_deleting_snapshot_that_doesnt_exist_errors
       assert_equal [{ 'error' => 'snapshot with name rocksoftware200 not found',
                       'meta' => 'Operation aborted' }].to_s,
-                   snapshot_api.snapshot_delete('rocksoftware200').to_s
+                      snapshot_api.snapshot_delete('rocksoftware200').parsed_response.to_s
     end
 
     def test_that_snapshot_delete_returns_200
@@ -60,7 +60,7 @@ describe AptlyCli::AptlySnapshot do
       assert_includes snapshot_api.snapshot_create(
         'testrepo_snap',
         'testrepo',
-        'the best again').to_s,
+        'the best again').parsed_response.to_s,
                       '"Name"=>"testrepo_snap", "CreatedAt"=>'
     end
 
@@ -72,7 +72,7 @@ describe AptlyCli::AptlySnapshot do
         'testrepo',
         'the best again')
       assert_includes snapshot_api.snapshot_list(
-        'name').to_s,
+        'name').parsed_response.to_s,
                       '"Name"=>"testrepo_snap"'
     end
   end
@@ -89,7 +89,7 @@ describe AptlyCli::AptlySnapshot do
       assert_includes snapshot_api.snapshot_update(
         'testrepo_snap_update_test',
         'testrepo_snap_update_test_new_name',
-        'Checkout my new name').to_s,
+        'Checkout my new name').parsed_response.to_s,
                       '"Name"=>"testrepo_snap_update_test_new_name", "CreatedAt"'
     end
 
@@ -131,7 +131,7 @@ describe AptlyCli::AptlySnapshot do
                    snapshot_api.snapshot_update(
                      'rocksoftware50_not_here',
                      'rocksoftware50_new_name_baby',
-                     'I am not a snapshot presently').to_s
+                     'I am not a snapshot presently').parsed_response.to_s
     end
 
     def test_failed_snapshot_show_snapshot_returns_404


### PR DESCRIPTION
Addresses https://github.com/sepulworld/aptly_cli/issues/154 which removes aptly-cli's dependency on multihttparty which is no longer maintained now that httparty directly support multipart file uploads which is required by Aptly server. 