### PR TITLE
Fix publish_update command when used without prefix

### DIFF
--- a/lib/aptly_publish.rb
+++ b/lib/aptly_publish.rb
@@ -112,7 +112,7 @@ module AptlyCli
       uri += if publish_options[:prefix]
                "/#{publish_options[:prefix]}"
              else
-               '/'
+               '/:.'
              end
 
       uri += "/#{publish_options[:distribution]}"


### PR DESCRIPTION
Without this patch, I not able to publish a repo without prefix using `aptly_cli`.

According to `#publish_drop`, the prefix have to be set to `:.`, so I copy/paste the code from `#publish_drop` to `#publish_update` and it works.